### PR TITLE
Merge/mzbe 55 design organ domain

### DIFF
--- a/src/main/kotlin/team/mozu/dsm/MozuBeV2Application.kt
+++ b/src/main/kotlin/team/mozu/dsm/MozuBeV2Application.kt
@@ -1,4 +1,4 @@
-package team.mozu.dms
+package team.mozu.dsm
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication

--- a/src/main/kotlin/team/mozu/dsm/MozuBeV2Application.kt
+++ b/src/main/kotlin/team/mozu/dsm/MozuBeV2Application.kt
@@ -2,7 +2,9 @@ package team.mozu.dsm
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing
 
+@EnableJpaAuditing
 @SpringBootApplication
 class MozuBeV2Application
 

--- a/src/main/kotlin/team/mozu/dsm/adapter/out/entity/OrganJpaEntity.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/out/entity/OrganJpaEntity.kt
@@ -1,4 +1,4 @@
-package team.mozu.dsm.infrastructure.persistence.organ
+package team.mozu.dsm.adapter.out.entity
 
 import jakarta.persistence.Column
 import jakarta.persistence.Entity

--- a/src/main/kotlin/team/mozu/dsm/adapter/out/entity/OrganJpaEntity.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/out/entity/OrganJpaEntity.kt
@@ -10,12 +10,12 @@ import java.util.UUID
 @Table(name = "tbl_admin") // JPQL은 도메인 모델 네이밍을 유지하고, SQL은 DB 스키마 변경에만 영향을 받도록 설계
 class OrganJpaEntity(
     id: UUID?,
-    adminCode: String,
+    organCode: String,
     organName: String,
     password: String
 ) : BaseUUIDEntity(id) {
     @Column(columnDefinition = "VARCHAR(5)", nullable = false, unique = true)
-    var adminCode: String = adminCode
+    var organCode: String = organCode
         protected set
 
     @Column(columnDefinition = "VARCHAR(100)", nullable = false)

--- a/src/main/kotlin/team/mozu/dsm/adapter/out/entity/OrganJpaEntity.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/out/entity/OrganJpaEntity.kt
@@ -14,7 +14,7 @@ class OrganJpaEntity(
     organName: String,
     password: String
 ) : BaseUUIDEntity(id) {
-    @Column(name = "admin_code", columnDefinition = "VARCHAR(5)", nullable = false, unique = true)
+    @Column(columnDefinition = "VARCHAR(5)", nullable = false, unique = true)
     var adminCode: String = adminCode
         protected set
 
@@ -22,7 +22,7 @@ class OrganJpaEntity(
     var organName: String = organName
         protected set
 
-    @Column(name = "password", columnDefinition = "VARCHAR(300)", nullable = false)
+    @Column(columnDefinition = "VARCHAR(300)", nullable = false)
     var password: String = password
         protected set
 }

--- a/src/main/kotlin/team/mozu/dsm/adapter/out/entity/OrganJpaEntity.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/out/entity/OrganJpaEntity.kt
@@ -7,7 +7,7 @@ import team.mozu.dsm.domain.BaseUUIDEntity
 import java.util.UUID
 
 @Entity
-@Table(name = "tb_admin") // JPQL은 도메인 모델 네이밍을 유지하고, SQL은 DB 스키마 변경에만 영향을 받도록 설계
+@Table(name = "tbl_admin") // JPQL은 도메인 모델 네이밍을 유지하고, SQL은 DB 스키마 변경에만 영향을 받도록 설계
 class OrganJpaEntity(
     id: UUID?,
     adminCode: String,

--- a/src/main/kotlin/team/mozu/dsm/adapter/out/entity/OrganJpaEntity.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/out/entity/OrganJpaEntity.kt
@@ -14,15 +14,15 @@ class OrganJpaEntity(
     organName: String,
     password: String
 ) : BaseUUIDEntity(id) {
-    @Column(name = "admin_code", length = 5, nullable = false, unique = true)
+    @Column(name = "admin_code", columnDefinition = "VARCHAR(5)", nullable = false, unique = true)
     var adminCode: String = adminCode
         protected set
 
-    @Column(length = 100, nullable = false)
+    @Column(columnDefinition = "VARCHAR(100)", nullable = false)
     var organName: String = organName
         protected set
 
-    @Column(name = "password", length = 300, nullable = false)
+    @Column(name = "password", columnDefinition = "VARCHAR(300)", nullable = false)
     var password: String = password
         protected set
 }

--- a/src/main/kotlin/team/mozu/dsm/adapter/out/entity/OrganJpaEntity.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/out/entity/OrganJpaEntity.kt
@@ -14,7 +14,7 @@ class OrganJpaEntity(
     organName: String,
     password: String
 ) : BaseUUIDEntity(id) {
-    @Column(name = "admin_id", length = 5, nullable = false, unique = true)
+    @Column(name = "admin_code", length = 5, nullable = false, unique = true)
     var adminCode: String = adminCode
         protected set
 

--- a/src/main/kotlin/team/mozu/dsm/adapter/out/entity/OrganJpaEntity.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/out/entity/OrganJpaEntity.kt
@@ -18,7 +18,7 @@ class OrganJpaEntity(
     var adminCode: String = adminCode
         protected set
 
-    @Column(name = "organ_name", length = 100, nullable = false)
+    @Column(length = 100, nullable = false)
     var organName: String = organName
         protected set
 

--- a/src/main/kotlin/team/mozu/dsm/adapter/out/entity/OrganJpaEntity.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/out/entity/OrganJpaEntity.kt
@@ -7,7 +7,7 @@ import team.mozu.dsm.domain.BaseUUIDEntity
 import java.util.UUID
 
 @Entity
-@Table(name = "tbl_admin") // JPQL은 도메인 모델 네이밍을 유지하고, SQL은 DB 스키마 변경에만 영향을 받도록 설계
+@Table(name = "tbl_organ") // JPQL은 도메인 모델 네이밍을 유지하고, SQL은 DB 스키마 변경에만 영향을 받도록 설계
 class OrganJpaEntity(
     id: UUID?,
     organCode: String,

--- a/src/main/kotlin/team/mozu/dsm/domain/BaseTimeEntity.kt
+++ b/src/main/kotlin/team/mozu/dsm/domain/BaseTimeEntity.kt
@@ -1,19 +1,27 @@
 package team.mozu.dsm.domain
 
+import jakarta.persistence.Column
 import jakarta.persistence.EntityListeners
 import jakarta.persistence.MappedSuperclass
 import org.springframework.data.annotation.CreatedDate
 import org.springframework.data.annotation.LastModifiedDate
 import org.springframework.data.jpa.domain.support.AuditingEntityListener
 import java.time.LocalDateTime
+import java.util.UUID
 
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener::class)
 abstract class BaseTimeEntity(
+    id: UUID? = null
+) : BaseUUIDEntity(id) {
     @CreatedDate
-    private val createdAt: LocalDateTime? = LocalDateTime.now(),
-    
+    @Column(updatable = false, nullable = false)
+    var createdAt: LocalDateTime? = null
+        protected set
+
     @LastModifiedDate
-    private val modifiedAt: LocalDateTime? = LocalDateTime.now()
-) {
+    @Column(nullable = false)
+    var modifiedAt: LocalDateTime? = null
+        protected set
+
 }

--- a/src/main/kotlin/team/mozu/dsm/domain/BaseTimeEntity.kt
+++ b/src/main/kotlin/team/mozu/dsm/domain/BaseTimeEntity.kt
@@ -23,5 +23,4 @@ abstract class BaseTimeEntity(
     @Column(nullable = false)
     var modifiedAt: LocalDateTime? = null
         protected set
-
 }

--- a/src/main/kotlin/team/mozu/dsm/domain/BaseTimeEntity.kt
+++ b/src/main/kotlin/team/mozu/dsm/domain/BaseTimeEntity.kt
@@ -1,0 +1,18 @@
+package team.mozu.dsm.domain
+
+import jakarta.persistence.EntityListeners
+import jakarta.persistence.MappedSuperclass
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import java.time.LocalDateTime
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener::class)
+abstract class BaseTimeEntity(
+    @CreatedDate
+    private val createdAt: LocalDateTime? = LocalDateTime.now(),
+    @LastModifiedDate
+    private val modifiedAt: LocalDateTime? = LocalDateTime.now()
+) {
+}

--- a/src/main/kotlin/team/mozu/dsm/domain/BaseTimeEntity.kt
+++ b/src/main/kotlin/team/mozu/dsm/domain/BaseTimeEntity.kt
@@ -12,6 +12,7 @@ import java.time.LocalDateTime
 abstract class BaseTimeEntity(
     @CreatedDate
     private val createdAt: LocalDateTime? = LocalDateTime.now(),
+    
     @LastModifiedDate
     private val modifiedAt: LocalDateTime? = LocalDateTime.now()
 ) {

--- a/src/main/kotlin/team/mozu/dsm/domain/BaseTimeEntity.kt
+++ b/src/main/kotlin/team/mozu/dsm/domain/BaseTimeEntity.kt
@@ -21,6 +21,6 @@ abstract class BaseTimeEntity(
 
     @LastModifiedDate
     @Column(nullable = false)
-    var modifiedAt: LocalDateTime? = null
+    var updatedAt: LocalDateTime? = null
         protected set
 }

--- a/src/main/kotlin/team/mozu/dsm/domain/BaseUUIDEntity.kt
+++ b/src/main/kotlin/team/mozu/dsm/domain/BaseUUIDEntity.kt
@@ -1,0 +1,23 @@
+package team.mozu.dsm.domain
+
+import jakarta.persistence.Column
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.Id
+import jakarta.persistence.MappedSuperclass
+import org.hibernate.annotations.GenericGenerator
+import org.springframework.data.domain.Persistable
+import java.util.*
+
+@MappedSuperclass
+abstract class BaseUUIDEntity(
+    @Id
+    @GeneratedValue(generator = "uuid4")
+    @GenericGenerator(name = "uuid4", strategy = "org.hibernate.id.UUIDGenerator")
+    @get:JvmName("getIdForJvm")
+    @Column(columnDefinition = "BINARY(16)", nullable = false)
+    var id: UUID?
+) : Persistable<UUID> {
+    override fun getId(): UUID? = this.id
+
+    override fun isNew(): Boolean = this.id == null
+}

--- a/src/main/kotlin/team/mozu/dsm/domain/organ/model/Organ.kt
+++ b/src/main/kotlin/team/mozu/dsm/domain/organ/model/Organ.kt
@@ -5,6 +5,6 @@ import java.util.UUID
 data class Organ(
     val id: UUID?,
     val adminCode: String,
-    val orgName: String,
+    val organName: String,
     val password: String
 )

--- a/src/main/kotlin/team/mozu/dsm/domain/organ/model/Organ.kt
+++ b/src/main/kotlin/team/mozu/dsm/domain/organ/model/Organ.kt
@@ -4,7 +4,7 @@ import java.util.UUID
 
 data class Organ(
     val id: UUID?,
-    val adminCode: String,
+    val organCode: String,
     val organName: String,
     val password: String
 )

--- a/src/main/kotlin/team/mozu/dsm/domain/organ/model/Organ.kt
+++ b/src/main/kotlin/team/mozu/dsm/domain/organ/model/Organ.kt
@@ -8,4 +8,3 @@ data class Organ(
     val orgName: String,
     val password: String
 )
-

--- a/src/main/kotlin/team/mozu/dsm/domain/organ/model/Organ.kt
+++ b/src/main/kotlin/team/mozu/dsm/domain/organ/model/Organ.kt
@@ -1,0 +1,11 @@
+package team.mozu.dsm.domain.organ.model
+
+import java.util.UUID
+
+data class Organ(
+    val id: UUID?,
+    val adminCode: String,
+    val orgName: String,
+    val password: String
+)
+

--- a/src/main/kotlin/team/mozu/dsm/infrastructure/persistence/organ/OrganJpaEntity.kt
+++ b/src/main/kotlin/team/mozu/dsm/infrastructure/persistence/organ/OrganJpaEntity.kt
@@ -1,0 +1,26 @@
+package team.mozu.dsm.infrastructure.persistence.organ
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import team.mozu.dsm.domain.BaseUUIDEntity
+import java.util.UUID
+
+@Entity(name = "tb_admin")
+class OrganJpaEntity(
+    id: UUID?,
+    adminCode: String,
+    organName: String,
+    password: String
+): BaseUUIDEntity(id) {
+    @Column(name = "admin_id", length = 5, nullable = false, unique = true)
+    var adminCode: String = adminCode
+        protected set
+
+    @Column(name = "org_name", length = 100, nullable = false)
+    var organName: String = organName
+        protected set
+
+    @Column(name = "password", length = 300, nullable = false)
+    var password: String = password
+        protected set
+}

--- a/src/main/kotlin/team/mozu/dsm/infrastructure/persistence/organ/OrganJpaEntity.kt
+++ b/src/main/kotlin/team/mozu/dsm/infrastructure/persistence/organ/OrganJpaEntity.kt
@@ -2,10 +2,12 @@ package team.mozu.dsm.infrastructure.persistence.organ
 
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
+import jakarta.persistence.Table
 import team.mozu.dsm.domain.BaseUUIDEntity
 import java.util.UUID
 
-@Entity(name = "tb_admin")
+@Entity
+@Table(name = "tb_admin") // JPQL은 도메인 모델 네이밍을 유지하고, SQL은 DB 스키마 변경에만 영향을 받도록 설계
 class OrganJpaEntity(
     id: UUID?,
     adminCode: String,

--- a/src/main/kotlin/team/mozu/dsm/infrastructure/persistence/organ/OrganJpaEntity.kt
+++ b/src/main/kotlin/team/mozu/dsm/infrastructure/persistence/organ/OrganJpaEntity.kt
@@ -18,7 +18,7 @@ class OrganJpaEntity(
     var adminCode: String = adminCode
         protected set
 
-    @Column(name = "org_name", length = 100, nullable = false)
+    @Column(name = "organ_name", length = 100, nullable = false)
     var organName: String = organName
         protected set
 

--- a/src/main/kotlin/team/mozu/dsm/infrastructure/persistence/organ/OrganJpaEntity.kt
+++ b/src/main/kotlin/team/mozu/dsm/infrastructure/persistence/organ/OrganJpaEntity.kt
@@ -11,7 +11,7 @@ class OrganJpaEntity(
     adminCode: String,
     organName: String,
     password: String
-): BaseUUIDEntity(id) {
+) : BaseUUIDEntity(id) {
     @Column(name = "admin_id", length = 5, nullable = false, unique = true)
     var adminCode: String = adminCode
         protected set

--- a/src/test/kotlin/team/mozu/dsm/MozuBeV2ApplicationTests.kt
+++ b/src/test/kotlin/team/mozu/dsm/MozuBeV2ApplicationTests.kt
@@ -1,4 +1,4 @@
-package team.mozu.dms
+package team.mozu.dsm
 
 import org.junit.jupiter.api.Test
 import org.springframework.boot.test.context.SpringBootTest

--- a/src/test/kotlin/team/mozu/dsm/MozuBeV2ApplicationTests.kt
+++ b/src/test/kotlin/team/mozu/dsm/MozuBeV2ApplicationTests.kt
@@ -9,5 +9,4 @@ class MozuBeV2ApplicationTests {
     @Test
     fun contextLoads() {
     }
-
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #16 

## 📝작업 내용

>  Organ 도메인 모델 추가
BaseUUIDEntity 추가
OrganJpaEntity 추가



### 
<img width="2928" height="1268" alt="image" src="https://github.com/user-attachments/assets/bff8abac-5d49-4457-a52f-d5af5361dec4" />


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신기능**
  * 기관(Organ) 관리용 도메인 및 JPA 엔티티 추가로 기관 코드·기관명·비밀번호를 저장·관리할 수 있습니다.
  * UUID 기반 기본 식별자 도입으로 식별 일관성 및 확장성 향상.
  * 생성/수정 시각 자동 기록(감사) 기능 추가로 변경 이력 자동 관리.

* **작업**
  * 애플리케이션 패키지 네임스페이스 정리 및 JPA 감사 활성화로 모듈 일관성 개선.

* **테스트**
  * 네임스페이스 변경에 맞춘 테스트 구성 업데이트.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->