### PR TITLE
Merge/mzbe 51 set custom exception

### DIFF
--- a/src/main/kotlin/team/mozu/dsm/global/error/ErrorResponse.kt
+++ b/src/main/kotlin/team/mozu/dsm/global/error/ErrorResponse.kt
@@ -14,7 +14,7 @@ data class ErrorResponse(
         fun of(errorCode: ErrorCode, description: String?): ErrorResponse =
             ErrorResponse(
                 message = errorCode.message,
-                status = errorCode.httpStatus.value(),   // 여기서 숫자로 변환
+                status = errorCode.httpStatus.value(), // 여기서 숫자로 변환
                 timestamp = LocalDateTime.now(),
                 description = description
             )
@@ -35,5 +35,4 @@ data class ErrorResponse(
                 description = description
             )
     }
-
 }

--- a/src/main/kotlin/team/mozu/dsm/global/error/ErrorResponse.kt
+++ b/src/main/kotlin/team/mozu/dsm/global/error/ErrorResponse.kt
@@ -1,5 +1,6 @@
 package team.mozu.dsm.global.error
 
+import org.springframework.http.HttpStatus
 import team.mozu.dsm.global.error.exception.ErrorCode
 import java.time.LocalDateTime
 
@@ -13,7 +14,15 @@ data class ErrorResponse(
         fun of(errorCode: ErrorCode, description: String?): ErrorResponse =
             ErrorResponse(
                 message = errorCode.message,
-                status = errorCode.status,
+                status = errorCode.httpStatus.value(),   // 여기서 숫자로 변환
+                timestamp = LocalDateTime.now(),
+                description = description
+            )
+
+        fun of(httpStatus: HttpStatus, message: String? = null, description: String? = null): ErrorResponse =
+            ErrorResponse(
+                message = message ?: httpStatus.reasonPhrase,
+                status = httpStatus.value(),
                 timestamp = LocalDateTime.now(),
                 description = description
             )
@@ -26,4 +35,5 @@ data class ErrorResponse(
                 description = description
             )
     }
+
 }

--- a/src/main/kotlin/team/mozu/dsm/global/error/ErrorResponse.kt
+++ b/src/main/kotlin/team/mozu/dsm/global/error/ErrorResponse.kt
@@ -1,0 +1,29 @@
+package team.mozu.dsm.global.error
+
+import team.mozu.dsm.global.error.exception.ErrorCode
+import java.time.LocalDateTime
+
+data class ErrorResponse(
+    val message: String,
+    val status: Int,
+    val timestamp: LocalDateTime,
+    val description: String?
+) {
+    companion object {
+        fun of(errorCode: ErrorCode, description: String?): ErrorResponse =
+            ErrorResponse(
+                message = errorCode.message,
+                status = errorCode.status,
+                timestamp = LocalDateTime.now(),
+                description = description
+            )
+
+        fun of(statusCode: Int, description: String?): ErrorResponse =
+            ErrorResponse(
+                message = description ?: "",
+                status = statusCode,
+                timestamp = LocalDateTime.now(),
+                description = description
+            )
+    }
+}

--- a/src/main/kotlin/team/mozu/dsm/global/error/GlobalExceptionFilter.kt
+++ b/src/main/kotlin/team/mozu/dsm/global/error/GlobalExceptionFilter.kt
@@ -9,7 +9,6 @@ import org.springframework.web.filter.OncePerRequestFilter
 import team.mozu.dsm.global.error.exception.ErrorCode
 import team.mozu.dsm.global.error.exception.MozuException
 
-@Component
 class GlobalExceptionFilter(
     private val objectMapper: ObjectMapper
 ) : OncePerRequestFilter() {

--- a/src/main/kotlin/team/mozu/dsm/global/error/GlobalExceptionFilter.kt
+++ b/src/main/kotlin/team/mozu/dsm/global/error/GlobalExceptionFilter.kt
@@ -5,6 +5,7 @@ import jakarta.servlet.FilterChain
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
 import org.springframework.web.filter.OncePerRequestFilter
 import team.mozu.dsm.global.error.exception.ErrorCode
 import team.mozu.dsm.global.error.exception.MozuException
@@ -43,7 +44,7 @@ class GlobalExceptionFilter(
         errorResponse: ErrorResponse
     ) {
         response.status = statusCode
-        response.contentType = "application/json"
+        response.contentType = MediaType.APPLICATION_JSON_VALUE
         response.characterEncoding = "UTF-8"
         objectMapper.writeValue(response.writer, errorResponse)
     }

--- a/src/main/kotlin/team/mozu/dsm/global/error/GlobalExceptionFilter.kt
+++ b/src/main/kotlin/team/mozu/dsm/global/error/GlobalExceptionFilter.kt
@@ -48,5 +48,4 @@ class GlobalExceptionFilter(
         response.characterEncoding = "UTF-8"
         objectMapper.writeValue(response.writer, errorResponse)
     }
-
 }

--- a/src/main/kotlin/team/mozu/dsm/global/error/GlobalExceptionFilter.kt
+++ b/src/main/kotlin/team/mozu/dsm/global/error/GlobalExceptionFilter.kt
@@ -1,0 +1,51 @@
+package team.mozu.dsm.global.error
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.stereotype.Component
+import org.springframework.web.filter.OncePerRequestFilter
+import team.mozu.dsm.global.error.exception.ErrorCode
+import team.mozu.dsm.global.error.exception.MozuException
+
+@Component
+class GlobalExceptionFilter(
+    private val objectMapper: ObjectMapper
+) : OncePerRequestFilter() {
+
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain
+    ) {
+        try {
+            filterChain.doFilter(request, response)
+        } catch (e: MozuException) {
+            val errorCode: ErrorCode = e.errorCode
+            writeErrorResponse(
+                response,
+                errorCode.status,
+                ErrorResponse.of(errorCode, errorCode.message)
+            )
+        } catch (e: Exception) {
+            e.printStackTrace()
+            writeErrorResponse(
+                response,
+                response.status,
+                ErrorResponse.of(response.status, e.message)
+            )
+        }
+    }
+
+    private fun writeErrorResponse(
+        response: HttpServletResponse,
+        statusCode: Int,
+        errorResponse: ErrorResponse
+    ) {
+        response.status = statusCode
+        response.contentType = "application/json"
+        response.characterEncoding = "UTF-8"
+        objectMapper.writeValue(response.writer, errorResponse)
+    }
+}

--- a/src/main/kotlin/team/mozu/dsm/global/error/GlobalExceptionFilter.kt
+++ b/src/main/kotlin/team/mozu/dsm/global/error/GlobalExceptionFilter.kt
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import jakarta.servlet.FilterChain
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
-import org.springframework.stereotype.Component
+import org.springframework.http.HttpStatus
 import org.springframework.web.filter.OncePerRequestFilter
 import team.mozu.dsm.global.error.exception.ErrorCode
 import team.mozu.dsm.global.error.exception.MozuException
@@ -24,15 +24,15 @@ class GlobalExceptionFilter(
             val errorCode: ErrorCode = e.errorCode
             writeErrorResponse(
                 response,
-                errorCode.status,
+                errorCode.httpStatus.value(), // HttpStatus → Int 변환
                 ErrorResponse.of(errorCode, errorCode.message)
             )
         } catch (e: Exception) {
             e.printStackTrace()
             writeErrorResponse(
                 response,
-                response.status,
-                ErrorResponse.of(response.status, e.message)
+                HttpStatus.INTERNAL_SERVER_ERROR.value(),
+                ErrorResponse.of(HttpStatus.INTERNAL_SERVER_ERROR, e.message)
             )
         }
     }
@@ -47,4 +47,5 @@ class GlobalExceptionFilter(
         response.characterEncoding = "UTF-8"
         objectMapper.writeValue(response.writer, errorResponse)
     }
+
 }

--- a/src/main/kotlin/team/mozu/dsm/global/error/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/team/mozu/dsm/global/error/GlobalExceptionHandler.kt
@@ -1,7 +1,6 @@
 package team.mozu.dsm.global.error
 
 import jakarta.validation.ConstraintViolationException
-import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.bind.annotation.ExceptionHandler
@@ -11,13 +10,14 @@ import team.mozu.dsm.global.error.exception.MozuException
 
 @RestControllerAdvice
 class GlobalExceptionHandler {
+
     // 비즈니스 로직 예외
     @ExceptionHandler(MozuException::class)
     fun handleTeam8Exception(e: MozuException): ResponseEntity<ErrorResponse> {
         val errorCode = e.errorCode
         val body = ErrorResponse.of(errorCode, errorCode.message)
         e.printStackTrace()
-        return ResponseEntity.status(errorCode.status).body(body)
+        return ResponseEntity.status(errorCode.httpStatus).body(body)
     }
 
     // DTO(@RequestBody) 필드 검증 실패
@@ -25,7 +25,7 @@ class GlobalExceptionHandler {
     fun handleMethodArgumentNotValid(e: MethodArgumentNotValidException): ResponseEntity<ErrorResponse> {
         val errorCode = ErrorCode.BAD_REQUEST
         val body = ErrorResponse.of(errorCode, errorCode.message)
-        return ResponseEntity.status(errorCode.status).body(body)
+        return ResponseEntity.status(errorCode.httpStatus).body(body)
     }
 
     // @PathVariable 검증 실패
@@ -33,7 +33,7 @@ class GlobalExceptionHandler {
     fun handleConstraintViolation(e: ConstraintViolationException): ResponseEntity<ErrorResponse> {
         val errorCode = ErrorCode.BAD_REQUEST
         val body = ErrorResponse.of(errorCode, errorCode.message)
-        return ResponseEntity.status(errorCode.status).body(body)
+        return ResponseEntity.status(errorCode.httpStatus).body(body)
     }
 
     // 그 외 예외
@@ -41,6 +41,6 @@ class GlobalExceptionHandler {
     fun handleException(e: Exception): ResponseEntity<ErrorResponse> {
         val errorCode = ErrorCode.INTERNAL_SERVER_ERROR
         val body = ErrorResponse.of(errorCode, e.message ?: errorCode.message)
-        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(body)
+        return ResponseEntity.status(errorCode.httpStatus).body(body)
     }
 }

--- a/src/main/kotlin/team/mozu/dsm/global/error/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/team/mozu/dsm/global/error/GlobalExceptionHandler.kt
@@ -1,0 +1,38 @@
+package team.mozu.dsm.global.error
+
+import jakarta.validation.ConstraintViolationException
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+import team.mozu.dsm.global.error.exception.ErrorCode
+import team.mozu.dsm.global.error.exception.MozuException
+
+@RestControllerAdvice
+class GlobalExceptionHandler {
+    // 비즈니스 로직 예외
+    @ExceptionHandler(MozuException::class)
+    fun handleTeam8Exception(e: MozuException): ResponseEntity<ErrorResponse> {
+        val errorCode = e.errorCode
+        val body = ErrorResponse.of(errorCode, errorCode.message)
+        e.printStackTrace()
+        return ResponseEntity.status(errorCode.status).body(body)
+    }
+
+    // validation 예외
+    @ExceptionHandler(ConstraintViolationException::class)
+    fun handleConstraintViolationException(e: ConstraintViolationException): ResponseEntity<ErrorResponse> {
+        val errorCode = ErrorCode.BAD_REQUEST
+        val body = ErrorResponse.of(errorCode, errorCode.message)
+        e.printStackTrace()
+        return ResponseEntity.status(errorCode.status).body(body)
+    }
+
+    // 그 외 예외
+    @ExceptionHandler(Exception::class)
+    fun handleException(e: Exception): ResponseEntity<ErrorResponse> {
+        val errorCode = ErrorCode.INTERNAL_SERVER_ERROR
+        val body = ErrorResponse.of(errorCode, e.message ?: errorCode.message)
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(body)
+    }
+}

--- a/src/main/kotlin/team/mozu/dsm/global/error/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/team/mozu/dsm/global/error/GlobalExceptionHandler.kt
@@ -3,6 +3,7 @@ package team.mozu.dsm.global.error
 import jakarta.validation.ConstraintViolationException
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
 import team.mozu.dsm.global.error.exception.ErrorCode
@@ -19,12 +20,19 @@ class GlobalExceptionHandler {
         return ResponseEntity.status(errorCode.status).body(body)
     }
 
-    // validation 예외
-    @ExceptionHandler(ConstraintViolationException::class)
-    fun handleConstraintViolationException(e: ConstraintViolationException): ResponseEntity<ErrorResponse> {
+    // DTO(@RequestBody) 필드 검증 실패
+    @ExceptionHandler(MethodArgumentNotValidException::class)
+    fun handleMethodArgumentNotValid(e: MethodArgumentNotValidException): ResponseEntity<ErrorResponse> {
         val errorCode = ErrorCode.BAD_REQUEST
         val body = ErrorResponse.of(errorCode, errorCode.message)
-        e.printStackTrace()
+        return ResponseEntity.status(errorCode.status).body(body)
+    }
+
+    // @PathVariable 검증 실패
+    @ExceptionHandler(ConstraintViolationException::class)
+    fun handleConstraintViolation(e: ConstraintViolationException): ResponseEntity<ErrorResponse> {
+        val errorCode = ErrorCode.BAD_REQUEST
+        val body = ErrorResponse.of(errorCode, errorCode.message)
         return ResponseEntity.status(errorCode.status).body(body)
     }
 

--- a/src/main/kotlin/team/mozu/dsm/global/error/exception/ErrorCode.kt
+++ b/src/main/kotlin/team/mozu/dsm/global/error/exception/ErrorCode.kt
@@ -10,5 +10,5 @@ enum class ErrorCode(
 
     // general
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "Bad Request"),
-    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Internal Server Error"),;
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Internal Server Error") ;
 }

--- a/src/main/kotlin/team/mozu/dsm/global/error/exception/ErrorCode.kt
+++ b/src/main/kotlin/team/mozu/dsm/global/error/exception/ErrorCode.kt
@@ -1,13 +1,14 @@
 package team.mozu.dsm.global.error.exception
 import com.fasterxml.jackson.annotation.JsonFormat
+import org.springframework.http.HttpStatus
 
 @JsonFormat(shape = JsonFormat.Shape.OBJECT)
 enum class ErrorCode(
-    val status: Int,
+    val httpStatus: HttpStatus,
     val message: String
 ) {
 
     // general
-    BAD_REQUEST(400, "Bad Request"),
-    INTERNAL_SERVER_ERROR(500, "Internal Server Error"),;
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, "Bad Request"),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Internal Server Error"),;
 }

--- a/src/main/kotlin/team/mozu/dsm/global/error/exception/ErrorCode.kt
+++ b/src/main/kotlin/team/mozu/dsm/global/error/exception/ErrorCode.kt
@@ -1,0 +1,13 @@
+package team.mozu.dsm.global.error.exception
+import com.fasterxml.jackson.annotation.JsonFormat
+
+@JsonFormat(shape = JsonFormat.Shape.OBJECT)
+enum class ErrorCode(
+    val status: Int,
+    val message: String
+) {
+
+    // general
+    BAD_REQUEST(400, "front fault"),
+    INTERNAL_SERVER_ERROR(500, "server fault");
+}

--- a/src/main/kotlin/team/mozu/dsm/global/error/exception/ErrorCode.kt
+++ b/src/main/kotlin/team/mozu/dsm/global/error/exception/ErrorCode.kt
@@ -8,6 +8,6 @@ enum class ErrorCode(
 ) {
 
     // general
-    BAD_REQUEST(400, "front fault"),
-    INTERNAL_SERVER_ERROR(500, "server fault");
+    BAD_REQUEST(400, "Bad Request"),
+    INTERNAL_SERVER_ERROR(500, "Internal Server Error"),;
 }

--- a/src/main/kotlin/team/mozu/dsm/global/error/exception/MozuException.kt
+++ b/src/main/kotlin/team/mozu/dsm/global/error/exception/MozuException.kt
@@ -1,0 +1,5 @@
+package team.mozu.dsm.global.error.exception
+
+abstract class MozuException(
+    val errorCode: ErrorCode
+) : RuntimeException()


### PR DESCRIPTION
## #️⃣연관된 이슈

> #18 

## 📝작업 내용

>custom 예외처리 세팅

###
<img width="3018" height="1386" alt="image" src="https://github.com/user-attachments/assets/a520f751-b0a7-4c63-871a-2a890037efd0" />


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신기능**
  * 전역 예외 처리 도입으로 모든 HTTP 요청에 대해 일관된 JSON 오류 응답 제공
  * 오류 응답 표준화(ErrorResponse: 상태 코드, 메시지, 타임스탬프, 설명 포함)로 진단성 향상
  * ErrorCode 열거형으로 주요 오류와 HTTP 상태 매핑 표준화(BAD_REQUEST, INTERNAL_SERVER_ERROR 등)
  * 공통 예외(MozuException) 기반 추가로 사용자 정의 예외의 일관된 처리 보장
  * 예외를 포착해 적절한 HTTP 상태와 표준화된 JSON 바디를 반환하는 필터와 핸들러 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->