### PR TITLE
Merge/mzbe 77 design article domain

### DIFF
--- a/src/main/kotlin/team/mozu/dsm/adapter/out/article/entity/ArticleJpaEntity.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/out/article/entity/ArticleJpaEntity.kt
@@ -14,7 +14,7 @@ class ArticleJpaEntity (
     @Column(nullable = false, columnDefinition = "VARCHAR(10000)")
     var articleDescription: String,
 
-    @Column(nullable = true, columnDefinition = "VARCHAR(255)")
+    @Column(columnDefinition = "VARCHAR(255)")
     var articleImage: String?,
 
     @Column(nullable = false)

--- a/src/main/kotlin/team/mozu/dsm/adapter/out/article/entity/ArticleJpaEntity.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/out/article/entity/ArticleJpaEntity.kt
@@ -1,0 +1,26 @@
+package team.mozu.dsm.adapter.out.article.entity
+
+import jakarta.persistence.*
+import team.mozu.dsm.adapter.out.organ.entity.OrganJpaEntity
+import team.mozu.dsm.global.entity.BaseTimeEntity
+
+@Entity
+@Table(name = "tbl_article")
+class ArticleJpaEntity (
+
+    @Column(nullable = false, columnDefinition = "VARCHAR(300)")
+    var articleName: String,
+
+    @Column(nullable = false, columnDefinition = "VARCHAR(10000)")
+    var articleDescription: String,
+
+    @Column(nullable = true, columnDefinition = "VARCHAR(255)")
+    var articleImage: String,
+
+    @Column(nullable = false)
+    var isDeleted: Boolean = false,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "organ_id", nullable = false)
+    var organ: OrganJpaEntity
+) : BaseTimeEntity()

--- a/src/main/kotlin/team/mozu/dsm/adapter/out/article/entity/ArticleJpaEntity.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/out/article/entity/ArticleJpaEntity.kt
@@ -15,7 +15,7 @@ class ArticleJpaEntity (
     var articleDescription: String,
 
     @Column(nullable = true, columnDefinition = "VARCHAR(255)")
-    var articleImage: String,
+    var articleImage: String?,
 
     @Column(nullable = false)
     var isDeleted: Boolean = false,

--- a/src/main/kotlin/team/mozu/dsm/adapter/out/article/persistence/mapper/ArticleMapper.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/out/article/persistence/mapper/ArticleMapper.kt
@@ -1,0 +1,12 @@
+package team.mozu.dsm.adapter.out.article.persistence.mapper
+
+import org.mapstruct.Mapper
+import team.mozu.dsm.adapter.out.article.entity.ArticleJpaEntity
+import team.mozu.dsm.domain.article.model.Article
+
+@Mapper(componentModel = "spring")
+interface ArticleMapper {
+    fun toModel(entity: ArticleJpaEntity): Article
+
+    fun toEntity(model: Article): ArticleJpaEntity
+}

--- a/src/main/kotlin/team/mozu/dsm/adapter/out/article/persistence/mapper/ArticleMapper.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/out/article/persistence/mapper/ArticleMapper.kt
@@ -1,32 +1,12 @@
 package team.mozu.dsm.adapter.out.article.persistence.mapper
 
-import org.springframework.stereotype.Component
+import org.mapstruct.Mapper
 import team.mozu.dsm.adapter.out.article.entity.ArticleJpaEntity
 import team.mozu.dsm.adapter.out.organ.entity.OrganJpaEntity
 import team.mozu.dsm.domain.article.model.Article
 
-@Component
-class ArticleMapper {
-
-    fun toModel(entity: ArticleJpaEntity): Article {
-        return Article(
-            id = entity.id,
-            organId = entity.organ.id!!,
-            articleName =  entity.articleName,
-            articleDescription = entity.articleDescription,
-            articleImage = entity.articleImage,
-            isDeleted = entity.isDeleted,
-            createAt = entity.createdAt
-        )
-    }
-
-    fun toEntity(model: Article, organ: OrganJpaEntity): ArticleJpaEntity {
-        return ArticleJpaEntity(
-            organ = organ,
-            articleName = model.articleName,
-            articleDescription = model.articleDescription,
-            articleImage = model.articleImage,
-            isDeleted = model.isDeleted
-        )
-    }
+@Mapper(componentModel = "spring")
+interface ArticleMapper {
+    fun toModel(entity: ArticleJpaEntity): Article
+    fun toEntity(model: Article, organ: OrganJpaEntity): ArticleJpaEntity
 }

--- a/src/main/kotlin/team/mozu/dsm/adapter/out/article/persistence/mapper/ArticleMapper.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/out/article/persistence/mapper/ArticleMapper.kt
@@ -1,12 +1,32 @@
 package team.mozu.dsm.adapter.out.article.persistence.mapper
 
-import org.mapstruct.Mapper
+import org.springframework.stereotype.Component
 import team.mozu.dsm.adapter.out.article.entity.ArticleJpaEntity
+import team.mozu.dsm.adapter.out.organ.entity.OrganJpaEntity
 import team.mozu.dsm.domain.article.model.Article
 
-@Mapper(componentModel = "spring")
-interface ArticleMapper {
-    fun toModel(entity: ArticleJpaEntity): Article
+@Component
+class ArticleMapper {
 
-    fun toEntity(model: Article): ArticleJpaEntity
+    fun toModel(entity: ArticleJpaEntity): Article {
+        return Article(
+            id = entity.id,
+            organId = entity.organ.id!!,
+            articleName =  entity.articleName,
+            articleDescription = entity.articleDescription,
+            articleImage = entity.articleImage,
+            isDeleted = entity.isDeleted,
+            createAt = entity.createdAt
+        )
+    }
+
+    fun toEntity(model: Article, organ: OrganJpaEntity): ArticleJpaEntity {
+        return ArticleJpaEntity(
+            organ = organ,
+            articleName = model.articleName,
+            articleDescription = model.articleDescription,
+            articleImage = model.articleImage,
+            isDeleted = model.isDeleted
+        )
+    }
 }

--- a/src/main/kotlin/team/mozu/dsm/adapter/out/article/persistence/repository/ArticleRepository.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/out/article/persistence/repository/ArticleRepository.kt
@@ -1,0 +1,7 @@
+package team.mozu.dsm.adapter.out.article.persistence.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import team.mozu.dsm.adapter.out.article.entity.ArticleJpaEntity
+import java.util.UUID
+
+interface ArticleRepository : JpaRepository<ArticleJpaEntity, UUID>

--- a/src/main/kotlin/team/mozu/dsm/domain/article/model/Article.kt
+++ b/src/main/kotlin/team/mozu/dsm/domain/article/model/Article.kt
@@ -11,7 +11,7 @@ data class Article (
     val articleName : String,
     val articleDescription : String,
     val articleImage : String?,
-    val createAt : LocalDateTime?,
+    val createAt : LocalDateTime = LocalDateTime.now(),
     val isDeleted : Boolean
 )
 

--- a/src/main/kotlin/team/mozu/dsm/domain/article/model/Article.kt
+++ b/src/main/kotlin/team/mozu/dsm/domain/article/model/Article.kt
@@ -11,7 +11,7 @@ data class Article (
     val articleName : String,
     val articleDescription : String,
     val articleImage : String?,
-    val createAt : LocalDateTime = LocalDateTime.now(),
+    val createdAt : LocalDateTime = LocalDateTime.now(),
     val updatedAt : LocalDateTime,
     val isDeleted : Boolean
 )

--- a/src/main/kotlin/team/mozu/dsm/domain/article/model/Article.kt
+++ b/src/main/kotlin/team/mozu/dsm/domain/article/model/Article.kt
@@ -1,0 +1,17 @@
+package team.mozu.dsm.domain.article.model
+
+import team.mozu.dsm.domain.annotation.Aggregate
+import java.time.LocalDateTime
+import java.util.UUID
+
+@Aggregate
+data class Article (
+    val id : UUID?,
+    val organId : UUID,
+    val articleName : String,
+    val articleDescription : String,
+    val articleImage : String,
+    val createDate : LocalDateTime,
+    val isDeleted : Boolean
+)
+

--- a/src/main/kotlin/team/mozu/dsm/domain/article/model/Article.kt
+++ b/src/main/kotlin/team/mozu/dsm/domain/article/model/Article.kt
@@ -12,6 +12,7 @@ data class Article (
     val articleDescription : String,
     val articleImage : String?,
     val createAt : LocalDateTime = LocalDateTime.now(),
+    val updatedAt : LocalDateTime,
     val isDeleted : Boolean
 )
 

--- a/src/main/kotlin/team/mozu/dsm/domain/article/model/Article.kt
+++ b/src/main/kotlin/team/mozu/dsm/domain/article/model/Article.kt
@@ -10,7 +10,7 @@ data class Article (
     val organId : UUID,
     val articleName : String,
     val articleDescription : String,
-    val articleImage : String,
+    val articleImage : String?,
     val createAt : LocalDateTime?,
     val isDeleted : Boolean
 )

--- a/src/main/kotlin/team/mozu/dsm/domain/article/model/Article.kt
+++ b/src/main/kotlin/team/mozu/dsm/domain/article/model/Article.kt
@@ -11,7 +11,7 @@ data class Article (
     val articleName : String,
     val articleDescription : String,
     val articleImage : String,
-    val createDate : LocalDateTime,
+    val createAt : LocalDateTime?,
     val isDeleted : Boolean
 )
 

--- a/src/main/kotlin/team/mozu/dsm/domain/article/model/Article.kt
+++ b/src/main/kotlin/team/mozu/dsm/domain/article/model/Article.kt
@@ -11,8 +11,8 @@ data class Article (
     val articleName : String,
     val articleDescription : String,
     val articleImage : String?,
-    val createdAt : LocalDateTime = LocalDateTime.now(),
-    val updatedAt : LocalDateTime,
+    val createdAt : LocalDateTime,
+    val updatedAt : LocalDateTime?,
     val isDeleted : Boolean
 )
 


### PR DESCRIPTION
## #️⃣연관된 이슈

- #32 

## 📝작업 내용

- `Article`및 `ArticleJpaEntity` 생성
- `ArticleRepository` 생성
- `ArticleMapper` 생성
### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

- 기사 도메인 설계 시 최대한 ERD를 유지하는 방향으로 구현하여서 필드의 타입이나 네이밍을 최대한 유지하였으나 아래 컬럼은 좀 더 정확한 명시를 위해 다음과 같이 변경하였습니다.
   **삭제 여부** : `delYN`-> `isDeleted`

- OrganMapper와는 다르게 Model과 Entity 변환 시 organ<-> organEntity 타입 불일치로 Mapper 적용을 못하였습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신규 기능
  - 게시글(제목, 설명, 이미지, 생성일, 수정일, 삭제여부) 관리 백엔드가 추가되어 게시글 저장·조회가 가능합니다.
- 기타
  - 도메인 모델과 영속성 계층 간 매핑 및 게시글↔기관 연동을 구성했습니다.
  - 사용자 인터페이스 변화는 없으며, 백엔드 데이터 구조와 안정성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->