### PR TITLE
Feature/mzbe 54 set querydsl

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -65,6 +65,12 @@ dependencies {
 
     // AWS S3
     implementation(Dependencies.AWS_S3)
+
+    // Querydsl
+    implementation(Dependencies.QUERYDSL_JPA)
+    kapt(Dependencies.QUERYDSL_APT)
+    kapt(Dependencies.JAKARTA_PERSISTENCE_API)
+    kapt(Dependencies.JAKARTA_ANNOTATION_API)
 }
 
 kotlin {
@@ -75,4 +81,14 @@ kotlin {
 
 tasks.withType<Test> {
     useJUnitPlatform()
+}
+
+kapt {
+    correctErrorTypes = true
+}
+
+sourceSets {
+    named("main") {
+        java.srcDirs("build/generated/source/kapt/main")
+    }
 }

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -32,4 +32,14 @@ object Dependencies {
 
     // AWS S3
     const val AWS_S3 = "software.amazon.awssdk:s3:${DependencyVersions.AWS_S3}"
+
+    // QueryDSL
+    const val QUERYDSL_JPA = "com.querydsl:querydsl-jpa:${DependencyVersions.QUERYDSL}:jakarta"
+    const val QUERYDSL_APT = "com.querydsl:querydsl-apt:${DependencyVersions.QUERYDSL}:jakarta"
+
+    // Q타입 생성 보조
+    const val JAKARTA_PERSISTENCE_API =
+        "jakarta.persistence:jakarta.persistence-api:${DependencyVersions.JAKARTA_PERSISTENCE}"
+    const val JAKARTA_ANNOTATION_API =
+        "jakarta.annotation:jakarta.annotation-api:${DependencyVersions.JAKARTA_ANNOTATION}"
 }

--- a/buildSrc/src/main/kotlin/DependencyVersions.kt
+++ b/buildSrc/src/main/kotlin/DependencyVersions.kt
@@ -2,4 +2,7 @@ object DependencyVersions {
     const val JWT = "0.12.6"
     const val MAPSTRUCT = "1.5.5.Final"
     const val AWS_S3 = "2.20.40"
+    const val QUERYDSL = "5.0.0"
+    const val JAKARTA_PERSISTENCE = "3.1.0"
+    const val JAKARTA_ANNOTATION = "2.1.1"
 }

--- a/src/main/kotlin/team/mozu/dsm/adapter/out/class/persistence/mapper/ClassMapper.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/out/class/persistence/mapper/ClassMapper.kt
@@ -26,7 +26,7 @@ class ClassMapper {
     }
 
     fun toEntity(model: Class, organ: OrganJpaEntity): ClassJpaEntity {
-    return ClassJpaEntity(
+        return ClassJpaEntity(
             organ = organ,
             className = model.className,
             maxInvRound = model.maxInvRound,

--- a/src/main/kotlin/team/mozu/dsm/adapter/out/class/persistence/mapper/ClassMapper.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/out/class/persistence/mapper/ClassMapper.kt
@@ -1,11 +1,11 @@
 package team.mozu.dsm.adapter.out.`class`.persistence.mapper
 
-import org.springframework.stereotype.Component
+import org.mapstruct.Mapper
 import team.mozu.dsm.adapter.out.`class`.entity.ClassJpaEntity
 import team.mozu.dsm.adapter.out.organ.entity.OrganJpaEntity
 import team.mozu.dsm.domain.`class`.model.Class
 
-@Component
+@Mapper(componentModel = "spring")
 class ClassMapper {
 
     fun toModel(entity: ClassJpaEntity): Class {

--- a/src/main/kotlin/team/mozu/dsm/global/config/querydsl/QueryDslConfig.kt
+++ b/src/main/kotlin/team/mozu/dsm/global/config/querydsl/QueryDslConfig.kt
@@ -1,0 +1,12 @@
+package team.mozu.dsm.global.config.querydsl
+
+import com.querydsl.jpa.impl.JPAQueryFactory
+import jakarta.persistence.EntityManager
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class QueryDslConfig {
+    @Bean
+    fun jpaQueryFactory(em: EntityManager) = JPAQueryFactory(em)
+}

--- a/src/main/kotlin/team/mozu/dsm/global/exception/s3/FailedDeleteException.kt
+++ b/src/main/kotlin/team/mozu/dsm/global/exception/s3/FailedDeleteException.kt
@@ -3,5 +3,4 @@ package team.mozu.dsm.global.exception.s3
 import team.mozu.dsm.global.error.exception.ErrorCode
 import team.mozu.dsm.global.error.exception.MozuException
 
-object FailedDeleteException : MozuException(ErrorCode.IMAGE_FAILED_DELETE) {
-}
+object FailedDeleteException : MozuException(ErrorCode.IMAGE_FAILED_DELETE)

--- a/src/main/kotlin/team/mozu/dsm/global/exception/s3/FailedUploadException.kt
+++ b/src/main/kotlin/team/mozu/dsm/global/exception/s3/FailedUploadException.kt
@@ -3,5 +3,4 @@ package team.mozu.dsm.global.exception.s3
 import team.mozu.dsm.global.error.exception.ErrorCode
 import team.mozu.dsm.global.error.exception.MozuException
 
-object FailedUploadException : MozuException(ErrorCode.IMAGE_UPLOAD_FAILED) {
-}
+object FailedUploadException : MozuException(ErrorCode.IMAGE_UPLOAD_FAILED)

--- a/src/main/kotlin/team/mozu/dsm/global/exception/s3/ImageNotFoundException.kt
+++ b/src/main/kotlin/team/mozu/dsm/global/exception/s3/ImageNotFoundException.kt
@@ -3,5 +3,4 @@ package team.mozu.dsm.global.exception.s3
 import team.mozu.dsm.global.error.exception.ErrorCode
 import team.mozu.dsm.global.error.exception.MozuException
 
-object ImageNotFoundException : MozuException(ErrorCode.IMAGE_NOT_FOUND) {
-}
+object ImageNotFoundException : MozuException(ErrorCode.IMAGE_NOT_FOUND)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -31,6 +31,6 @@ cloud:
     aws:
         s3:
             bucket: ${BUCKET_NAME}
-            url-prefix: ${S3_URL_PREFIX}
+            url-prefix: ${MOZU_IMAGE_FOLDER}
         region:
             static: ${AWS_REGION}


### PR DESCRIPTION
## #37 

> ex) #이슈번호, #이슈번호

## Query DSL Setting

> Query DSL 의존성 추가
> QueryDslConfig
>s3 관련 리펙토링

### 
<img width="3024" height="1516" alt="image" src="https://github.com/user-attachments/assets/cbde187c-870b-48d6-9352-0df35ea3bd7f" />

## 💬리뷰 요구사항(선택)

> Q클래스는 project를 우클릭하여 Project Files 에서 확인하실 수 있습니다
>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 없음
- Chores
  - Querydsl 의존성 및 애노테이션 프로세싱(kapt) 추가로 빌드/컴파일 체인 확장 및 생성된 소스 포함
  - 의존성/버전 상수 추가
  - 이미지 URL 프리픽스 환경 변수명 변경(MOZU_IMAGE_FOLDER)
- Refactor
  - QueryDSL JPAQueryFactory 빈 추가로 조회 구성 보강(의존성 주입 정리)
  - 매퍼 어노테이션을 MapStruct 기반으로 변경하여 통합 방식 조정
- Style
  - 예외 객체 선언의 불필요한 본문 제거 및 포맷 정리
<!-- end of auto-generated comment: release notes by coderabbit.ai -->