### PR TITLE
Merge/mzbe 93 order domain design

### DIFF
--- a/src/main/kotlin/team/mozu/dsm/adapter/out/lesson/persistence/mapper/LessonItemMapper.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/out/lesson/persistence/mapper/LessonItemMapper.kt
@@ -11,13 +11,15 @@ import team.mozu.dsm.domain.lesson.model.LessonItem
 @Mapper(componentModel = "spring")
 abstract class LessonItemMapper {
 
-    @Mapping(target = "lessonId", source = "lesson.id")
-    @Mapping(target = "itemId", source = "item.id")
+    @Mapping(target = "lessonItemId", source = "lessonItemId")
     abstract fun toModel(entity: LessonItemJpaEntity): LessonItem
 
     fun toEntity(model: LessonItem, lesson: LessonJpaEntity, item: ItemJpaEntity): LessonItemJpaEntity {
         return LessonItemJpaEntity(
-            lessonItemId = LessonItemId(model.lessonId, model.itemId),
+            lessonItemId = LessonItemId(
+                model.lessonItemId.lessonId,
+                model.lessonItemId.itemId
+            ),
             lesson = lesson,
             item = item,
             currentMoney = model.currentMoney,

--- a/src/main/kotlin/team/mozu/dsm/adapter/out/team/entity/OrderItemJpaEntity.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/out/team/entity/OrderItemJpaEntity.kt
@@ -41,23 +41,10 @@ class OrderItemJpaEntity(
     @Column(nullable = false)
     var invCnt: Int,
 
-    /**
-     * 객체 참조가 아닌 값을 직접 저장
-     */
-    @AttributeOverrides(
-        AttributeOverride(name = "lessonId", column = Column(name = "lesson_id")),
-        AttributeOverride(name = "itemId", column = Column(name = "item_id"))
-    )
-    @Embedded
-    var lessonItemId: LessonItemId,
-
-    /**
-     * 위의 lessonItemId에 저장된 값들을 이용해서 실제 LessonItemJpaEntity 객체를 조회 및 참조
-     */
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumns(
-        JoinColumn(name = "lesson_id", referencedColumnName = "lesson_id", insertable = false, updatable = false),
-        JoinColumn(name = "item_id", referencedColumnName = "item_id", insertable = false, updatable = false)
+        JoinColumn(name = "lesson_id", referencedColumnName = "lesson_id", nullable = false),
+        JoinColumn(name = "item_id", referencedColumnName = "item_id", nullable = false)
     )
     var lessonItem: LessonItemJpaEntity,
 

--- a/src/main/kotlin/team/mozu/dsm/adapter/out/team/entity/OrderItemJpaEntity.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/out/team/entity/OrderItemJpaEntity.kt
@@ -12,7 +12,6 @@ import jakarta.persistence.Table
 import team.mozu.dsm.adapter.out.lesson.entity.LessonItemJpaEntity
 import team.mozu.dsm.domain.team.type.OrderType
 import team.mozu.dsm.global.entity.BaseTimeEntity
-import java.time.LocalDateTime
 
 @Entity
 @Table(name = "tbl_team_order")

--- a/src/main/kotlin/team/mozu/dsm/adapter/out/team/entity/OrderItemJpaEntity.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/out/team/entity/OrderItemJpaEntity.kt
@@ -18,7 +18,7 @@ import java.time.LocalDateTime
 
 @Entity
 @Table(name = "tbl_order_item")
-class OrderItemJpaEntity (
+class OrderItemJpaEntity(
 
     @Column(nullable = false)
     var orderType: OrderType,

--- a/src/main/kotlin/team/mozu/dsm/adapter/out/team/entity/OrderItemJpaEntity.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/out/team/entity/OrderItemJpaEntity.kt
@@ -5,6 +5,8 @@ import jakarta.persistence.AttributeOverrides
 import jakarta.persistence.Column
 import jakarta.persistence.Embedded
 import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
 import jakarta.persistence.FetchType
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.JoinColumns
@@ -20,6 +22,7 @@ import java.time.LocalDateTime
 @Table(name = "tbl_order_item")
 class OrderItemJpaEntity(
 
+    @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     var orderType: OrderType,
 

--- a/src/main/kotlin/team/mozu/dsm/adapter/out/team/entity/OrderItemJpaEntity.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/out/team/entity/OrderItemJpaEntity.kt
@@ -1,9 +1,6 @@
 package team.mozu.dsm.adapter.out.team.entity
 
-import jakarta.persistence.AttributeOverride
-import jakarta.persistence.AttributeOverrides
 import jakarta.persistence.Column
-import jakarta.persistence.Embedded
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
@@ -13,7 +10,6 @@ import jakarta.persistence.JoinColumns
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
 import team.mozu.dsm.adapter.out.lesson.entity.LessonItemJpaEntity
-import team.mozu.dsm.adapter.out.lesson.entity.id.LessonItemId
 import team.mozu.dsm.domain.team.type.OrderType
 import team.mozu.dsm.global.entity.BaseTimeEntity
 import java.time.LocalDateTime

--- a/src/main/kotlin/team/mozu/dsm/adapter/out/team/entity/OrderItemJpaEntity.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/out/team/entity/OrderItemJpaEntity.kt
@@ -15,8 +15,11 @@ import team.mozu.dsm.global.entity.BaseTimeEntity
 import java.time.LocalDateTime
 
 @Entity
-@Table(name = "tbl_order_item")
+@Table(name = "tbl_team_order")
 class OrderItemJpaEntity(
+
+    @Column(nullable = false, columnDefinition = "VARCHAR(100)")
+    var itemName: String,
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
@@ -32,10 +35,7 @@ class OrderItemJpaEntity(
     var totalAmount: Long,
 
     @Column(nullable = false)
-    var orderedAt: LocalDateTime,
-
-    @Column(nullable = false)
-    var invCnt: Int,
+    var invCount: Int,
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumns(

--- a/src/main/kotlin/team/mozu/dsm/adapter/out/team/entity/OrderItemJpaEntity.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/out/team/entity/OrderItemJpaEntity.kt
@@ -1,0 +1,64 @@
+package team.mozu.dsm.adapter.out.team.entity
+
+import jakarta.persistence.AttributeOverride
+import jakarta.persistence.AttributeOverrides
+import jakarta.persistence.Column
+import jakarta.persistence.Embedded
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.JoinColumns
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import team.mozu.dsm.adapter.out.lesson.entity.LessonItemJpaEntity
+import team.mozu.dsm.adapter.out.lesson.entity.id.LessonItemId
+import team.mozu.dsm.domain.team.type.OrderType
+import team.mozu.dsm.global.entity.BaseTimeEntity
+import java.time.LocalDateTime
+
+@Entity
+@Table(name = "tbl_order_item")
+class OrderItemJpaEntity (
+
+    @Column(nullable = false)
+    var orderType: OrderType,
+
+    @Column(nullable = false)
+    var orderCount: Int,
+
+    @Column(nullable = false)
+    var itemPrice: Long,
+
+    @Column(nullable = false)
+    var totalAmount: Long,
+
+    @Column(nullable = false)
+    var orderedAt: LocalDateTime,
+
+    @Column(nullable = false)
+    var invCnt: Int,
+
+    /**
+     * 객체 참조가 아닌 값을 직접 저장
+     */
+    @AttributeOverrides(
+        AttributeOverride(name = "lessonId", column = Column(name = "lesson_id")),
+        AttributeOverride(name = "itemId", column = Column(name = "item_id"))
+    )
+    @Embedded
+    var lessonItemId: LessonItemId,
+
+    /**
+     * 위의 lessonItemId에 저장된 값들을 이용해서 실제 LessonItemJpaEntity 객체를 조회 및 참조
+     */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumns(
+        JoinColumn(name = "lesson_id", referencedColumnName = "lesson_id", insertable = false, updatable = false),
+        JoinColumn(name = "item_id", referencedColumnName = "item_id", insertable = false, updatable = false)
+    )
+    var lessonItem: LessonItemJpaEntity,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "team_id", nullable = false)
+    var team: TeamJpaEntity
+) : BaseTimeEntity()

--- a/src/main/kotlin/team/mozu/dsm/adapter/out/team/entity/StockJpaEntity.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/out/team/entity/StockJpaEntity.kt
@@ -9,7 +9,7 @@ import jakarta.persistence.Table
 import team.mozu.dsm.global.entity.BaseTimeEntity
 
 @Entity
-@Table(name = "tbl_hold_item")
+@Table(name = "tbl_stock")
 class StockJpaEntity(
 
     @Column(nullable = false, columnDefinition = "VARCHAR(100)")

--- a/src/main/kotlin/team/mozu/dsm/adapter/out/team/entity/StockJpaEntity.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/out/team/entity/StockJpaEntity.kt
@@ -4,8 +4,10 @@ import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.FetchType
 import jakarta.persistence.JoinColumn
+import jakarta.persistence.JoinColumns
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
+import team.mozu.dsm.adapter.out.lesson.entity.LessonItemJpaEntity
 import team.mozu.dsm.global.entity.BaseTimeEntity
 
 @Entity
@@ -16,7 +18,10 @@ class StockJpaEntity(
     var itemName: String,
 
     @Column(nullable = false)
-    var itemCount: Long,
+    var avgPurchasePrice: Long,
+
+    @Column(nullable = false)
+    var quantity: Int,
 
     @Column(nullable = false)
     var buyMoney: Long,
@@ -29,6 +34,13 @@ class StockJpaEntity(
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "team_id", nullable = false)
-    var team: TeamJpaEntity
+    var team: TeamJpaEntity,
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumns(
+        JoinColumn(name = "lesson_id", referencedColumnName = "lesson_id", nullable = false),
+        JoinColumn(name = "item_id", referencedColumnName = "item_id", nullable = false)
+    )
+    var lessonItem: LessonItemJpaEntity
 
 ) : BaseTimeEntity()

--- a/src/main/kotlin/team/mozu/dsm/adapter/out/team/persistence/mapper/OrderItemMapper.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/out/team/persistence/mapper/OrderItemMapper.kt
@@ -1,0 +1,30 @@
+package team.mozu.dsm.adapter.out.team.persistence.mapper
+
+import org.mapstruct.Mapper
+import org.mapstruct.Mapping
+import team.mozu.dsm.adapter.out.lesson.entity.LessonItemJpaEntity
+import team.mozu.dsm.adapter.out.team.entity.OrderItemJpaEntity
+import team.mozu.dsm.adapter.out.team.entity.TeamJpaEntity
+import team.mozu.dsm.domain.team.model.OrderItem
+
+@Mapper
+abstract class OrderItemMapper {
+
+    @Mapping(target = "teamId", source = "team.id")
+    @Mapping(target = "lessonItemId", source = "lessonItemId")
+    abstract fun toModel(entity: OrderItemJpaEntity): OrderItem
+
+    fun toEntity(model: OrderItem,lessonItem: LessonItemJpaEntity ,team: TeamJpaEntity): OrderItemJpaEntity {
+        return OrderItemJpaEntity(
+            lessonItemId = lessonItem.lessonItemId,
+            lessonItem = lessonItem,
+            team = team,
+            orderType = model.orderType,
+            orderCount = model.orderCount,
+            itemPrice = model.itemPrice,
+            totalAmount = model.totalAmount,
+            orderedAt = model.orderedAt,
+            invCnt = model.invCnt
+        )
+    }
+}

--- a/src/main/kotlin/team/mozu/dsm/adapter/out/team/persistence/mapper/OrderItemMapper.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/out/team/persistence/mapper/OrderItemMapper.kt
@@ -18,7 +18,7 @@ import team.mozu.dsm.domain.team.model.OrderItem
 abstract class OrderItemMapper {
 
     @Mapping(target = "teamId", source = "team.id")
-    @Mapping(target = "lessonItemId", source = "lessonItem")
+    @Mapping(target = "lessonItemId", source = "lessonItem.lessonItemId")
     abstract fun toModel(entity: OrderItemJpaEntity): OrderItem
 
     fun toEntity(model: OrderItem, lessonItem: LessonItemJpaEntity, team: TeamJpaEntity): OrderItemJpaEntity {

--- a/src/main/kotlin/team/mozu/dsm/adapter/out/team/persistence/mapper/OrderItemMapper.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/out/team/persistence/mapper/OrderItemMapper.kt
@@ -11,12 +11,11 @@ import team.mozu.dsm.domain.team.model.OrderItem
 abstract class OrderItemMapper {
 
     @Mapping(target = "teamId", source = "team.id")
-    @Mapping(target = "lessonItemId", source = "lessonItemId")
+    @Mapping(target = "lessonItem", source = "lessonItem")
     abstract fun toModel(entity: OrderItemJpaEntity): OrderItem
 
     fun toEntity(model: OrderItem, lessonItem: LessonItemJpaEntity, team: TeamJpaEntity): OrderItemJpaEntity {
         return OrderItemJpaEntity(
-            lessonItemId = lessonItem.lessonItemId,
             lessonItem = lessonItem,
             team = team,
             orderType = model.orderType,

--- a/src/main/kotlin/team/mozu/dsm/adapter/out/team/persistence/mapper/OrderItemMapper.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/out/team/persistence/mapper/OrderItemMapper.kt
@@ -18,19 +18,19 @@ import team.mozu.dsm.domain.team.model.OrderItem
 abstract class OrderItemMapper {
 
     @Mapping(target = "teamId", source = "team.id")
-    @Mapping(target = "lessonItem", source = "lessonItem")
+    @Mapping(target = "lessonItemId", source = "lessonItem")
     abstract fun toModel(entity: OrderItemJpaEntity): OrderItem
 
     fun toEntity(model: OrderItem, lessonItem: LessonItemJpaEntity, team: TeamJpaEntity): OrderItemJpaEntity {
         return OrderItemJpaEntity(
             lessonItem = lessonItem,
             team = team,
+            itemName = model.itemName,
             orderType = model.orderType,
             orderCount = model.orderCount,
             itemPrice = model.itemPrice,
             totalAmount = model.totalAmount,
-            orderedAt = model.orderedAt,
-            invCnt = model.invCnt
+            invCount = model.invCount
         )
     }
 }

--- a/src/main/kotlin/team/mozu/dsm/adapter/out/team/persistence/mapper/OrderItemMapper.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/out/team/persistence/mapper/OrderItemMapper.kt
@@ -3,11 +3,18 @@ package team.mozu.dsm.adapter.out.team.persistence.mapper
 import org.mapstruct.Mapper
 import org.mapstruct.Mapping
 import team.mozu.dsm.adapter.out.lesson.entity.LessonItemJpaEntity
+import team.mozu.dsm.adapter.out.lesson.persistence.mapper.LessonItemMapper
 import team.mozu.dsm.adapter.out.team.entity.OrderItemJpaEntity
 import team.mozu.dsm.adapter.out.team.entity.TeamJpaEntity
 import team.mozu.dsm.domain.team.model.OrderItem
 
-@Mapper(componentModel = "spring")
+@Mapper(
+    componentModel = "spring",
+    /**
+     * 중첩된 객체 매핑을 위해 다른 매퍼를 참조
+     */
+    uses = [LessonItemMapper::class]
+)
 abstract class OrderItemMapper {
 
     @Mapping(target = "teamId", source = "team.id")

--- a/src/main/kotlin/team/mozu/dsm/adapter/out/team/persistence/mapper/OrderItemMapper.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/out/team/persistence/mapper/OrderItemMapper.kt
@@ -7,7 +7,7 @@ import team.mozu.dsm.adapter.out.team.entity.OrderItemJpaEntity
 import team.mozu.dsm.adapter.out.team.entity.TeamJpaEntity
 import team.mozu.dsm.domain.team.model.OrderItem
 
-@Mapper
+@Mapper(componentModel = "spring")
 abstract class OrderItemMapper {
 
     @Mapping(target = "teamId", source = "team.id")

--- a/src/main/kotlin/team/mozu/dsm/adapter/out/team/persistence/mapper/OrderItemMapper.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/out/team/persistence/mapper/OrderItemMapper.kt
@@ -14,7 +14,7 @@ abstract class OrderItemMapper {
     @Mapping(target = "lessonItemId", source = "lessonItemId")
     abstract fun toModel(entity: OrderItemJpaEntity): OrderItem
 
-    fun toEntity(model: OrderItem,lessonItem: LessonItemJpaEntity ,team: TeamJpaEntity): OrderItemJpaEntity {
+    fun toEntity(model: OrderItem, lessonItem: LessonItemJpaEntity, team: TeamJpaEntity): OrderItemJpaEntity {
         return OrderItemJpaEntity(
             lessonItemId = lessonItem.lessonItemId,
             lessonItem = lessonItem,

--- a/src/main/kotlin/team/mozu/dsm/adapter/out/team/persistence/mapper/StockMapper.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/out/team/persistence/mapper/StockMapper.kt
@@ -3,11 +3,15 @@ package team.mozu.dsm.adapter.out.team.persistence.mapper
 import org.mapstruct.Mapper
 import org.mapstruct.Mapping
 import team.mozu.dsm.adapter.out.lesson.entity.LessonItemJpaEntity
+import team.mozu.dsm.adapter.out.lesson.persistence.mapper.LessonItemMapper
 import team.mozu.dsm.adapter.out.team.entity.StockJpaEntity
 import team.mozu.dsm.adapter.out.team.entity.TeamJpaEntity
 import team.mozu.dsm.domain.team.model.Stock
 
-@Mapper(componentModel = "spring")
+@Mapper(
+    componentModel = "spring",
+    uses = [LessonItemMapper::class]
+)
 abstract class StockMapper {
 
     /**

--- a/src/main/kotlin/team/mozu/dsm/adapter/out/team/persistence/mapper/StockMapper.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/out/team/persistence/mapper/StockMapper.kt
@@ -19,7 +19,7 @@ abstract class StockMapper {
      * PK(team.id)를 target(teamId)과 매핑하기 위해 명시적으로 지정
      */
     @Mapping(target = "teamId", source = "team.id")
-    @Mapping(target = "lessonItemId", source = "lessonItem")
+    @Mapping(target = "lessonItemId", source = "lessonItem.lessonItemId")
     abstract fun toModel(entity: StockJpaEntity): Stock
 
     /**

--- a/src/main/kotlin/team/mozu/dsm/adapter/out/team/persistence/mapper/StockMapper.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/out/team/persistence/mapper/StockMapper.kt
@@ -2,6 +2,7 @@ package team.mozu.dsm.adapter.out.team.persistence.mapper
 
 import org.mapstruct.Mapper
 import org.mapstruct.Mapping
+import team.mozu.dsm.adapter.out.lesson.entity.LessonItemJpaEntity
 import team.mozu.dsm.adapter.out.team.entity.StockJpaEntity
 import team.mozu.dsm.adapter.out.team.entity.TeamJpaEntity
 import team.mozu.dsm.domain.team.model.Stock
@@ -14,17 +15,20 @@ abstract class StockMapper {
      * PK(team.id)를 target(teamId)과 매핑하기 위해 명시적으로 지정
      */
     @Mapping(target = "teamId", source = "team.id")
+    @Mapping(target = "lessonItemId", source = "lessonItem")
     abstract fun toModel(entity: StockJpaEntity): Stock
 
     /**
      * MapStruct는 DB 조회를 지원하지 않으므로 toEntity 메서드는 수동 구현 방식을 사용함
      * (StockJpaEntity에는 TeamJpaEntity 객체 필드만 존재 -> teamId를 엔티티에서 찾으려면 DB 조회가 필요)
      */
-    fun toEntity(model: Stock, team: TeamJpaEntity): StockJpaEntity {
+    fun toEntity(model: Stock, team: TeamJpaEntity, lessonItem: LessonItemJpaEntity): StockJpaEntity {
         return StockJpaEntity(
             team = team,
+            lessonItem = lessonItem,
             itemName = model.itemName,
-            itemCount = model.itemCount,
+            avgPurchasePrice = model.avgPurchasePrice,
+            quantity = model.quantity,
             buyMoney = model.buyMoney,
             valProfit = model.valProfit,
             profitNum = model.profitNum

--- a/src/main/kotlin/team/mozu/dsm/adapter/out/team/persistence/repository/OrderItemRepository.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/out/team/persistence/repository/OrderItemRepository.kt
@@ -1,0 +1,7 @@
+package team.mozu.dsm.adapter.out.team.persistence.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import team.mozu.dsm.adapter.out.team.entity.OrderItemJpaEntity
+import java.util.UUID
+
+interface OrderItemRepository : JpaRepository<OrderItemJpaEntity, UUID>

--- a/src/main/kotlin/team/mozu/dsm/domain/lesson/model/LessonItem.kt
+++ b/src/main/kotlin/team/mozu/dsm/domain/lesson/model/LessonItem.kt
@@ -1,12 +1,10 @@
 package team.mozu.dsm.domain.lesson.model
 
 import team.mozu.dsm.domain.annotation.Aggregate
-import java.util.UUID
 
 @Aggregate
 data class LessonItem(
-    val lessonId: UUID,
-    val itemId: UUID,
+    val lessonItemId: LessonItemId,
     val currentMoney: Int,
     val round1Money: Int,
     val round2Money: Int,

--- a/src/main/kotlin/team/mozu/dsm/domain/lesson/model/LessonItemId.kt
+++ b/src/main/kotlin/team/mozu/dsm/domain/lesson/model/LessonItemId.kt
@@ -1,0 +1,8 @@
+package team.mozu.dsm.domain.lesson.model
+
+import java.util.UUID
+
+data class LessonItemId(
+    val lessonId: UUID,
+    val itemId: UUID
+)

--- a/src/main/kotlin/team/mozu/dsm/domain/team/model/OrderItem.kt
+++ b/src/main/kotlin/team/mozu/dsm/domain/team/model/OrderItem.kt
@@ -10,7 +10,7 @@ import java.util.UUID
 data class OrderItem(
     val id: UUID?,
     val lessonItemId: LessonItemId,
-    val teamId: String,
+    val teamId: UUID,
     val itemName: String,
     val orderType: OrderType,
     val orderCount: Int,

--- a/src/main/kotlin/team/mozu/dsm/domain/team/model/OrderItem.kt
+++ b/src/main/kotlin/team/mozu/dsm/domain/team/model/OrderItem.kt
@@ -1,0 +1,24 @@
+package team.mozu.dsm.domain.team.model
+
+import team.mozu.dsm.adapter.out.lesson.entity.id.LessonItemId
+import team.mozu.dsm.domain.annotation.Aggregate
+import team.mozu.dsm.domain.lesson.model.LessonItem
+import team.mozu.dsm.domain.team.type.OrderType
+import java.time.LocalDateTime
+import java.util.UUID
+
+@Aggregate
+data class OrderItem (
+    val id: UUID?,
+    val lessonItemId: LessonItemId,
+    val lessonItem: LessonItem,
+    val teamId: String,
+    val orderType: OrderType,
+    val orderCount: Int,
+    val itemPrice: Long,
+    val totalAmount: Long,
+    val orderedAt: LocalDateTime,
+    val invCnt: Int,
+    val createdAt: LocalDateTime,
+    val updatedAt: LocalDateTime?
+)

--- a/src/main/kotlin/team/mozu/dsm/domain/team/model/OrderItem.kt
+++ b/src/main/kotlin/team/mozu/dsm/domain/team/model/OrderItem.kt
@@ -1,7 +1,7 @@
 package team.mozu.dsm.domain.team.model
 
 import team.mozu.dsm.domain.annotation.Aggregate
-import team.mozu.dsm.domain.lesson.model.LessonItem
+import team.mozu.dsm.domain.lesson.model.LessonItemId
 import team.mozu.dsm.domain.team.type.OrderType
 import java.time.LocalDateTime
 import java.util.UUID
@@ -9,14 +9,14 @@ import java.util.UUID
 @Aggregate
 data class OrderItem(
     val id: UUID?,
-    val lessonItem: LessonItem,
+    val lessonItemId: LessonItemId,
     val teamId: String,
+    val itemName: String,
     val orderType: OrderType,
     val orderCount: Int,
     val itemPrice: Long,
     val totalAmount: Long,
-    val orderedAt: LocalDateTime,
-    val invCnt: Int,
+    val invCount: Int,
     val createdAt: LocalDateTime,
     val updatedAt: LocalDateTime?
 )

--- a/src/main/kotlin/team/mozu/dsm/domain/team/model/OrderItem.kt
+++ b/src/main/kotlin/team/mozu/dsm/domain/team/model/OrderItem.kt
@@ -1,6 +1,5 @@
 package team.mozu.dsm.domain.team.model
 
-import team.mozu.dsm.adapter.out.lesson.entity.id.LessonItemId
 import team.mozu.dsm.domain.annotation.Aggregate
 import team.mozu.dsm.domain.lesson.model.LessonItem
 import team.mozu.dsm.domain.team.type.OrderType
@@ -10,7 +9,6 @@ import java.util.UUID
 @Aggregate
 data class OrderItem(
     val id: UUID?,
-    val lessonItemId: LessonItemId,
     val lessonItem: LessonItem,
     val teamId: String,
     val orderType: OrderType,

--- a/src/main/kotlin/team/mozu/dsm/domain/team/model/OrderItem.kt
+++ b/src/main/kotlin/team/mozu/dsm/domain/team/model/OrderItem.kt
@@ -8,7 +8,7 @@ import java.time.LocalDateTime
 import java.util.UUID
 
 @Aggregate
-data class OrderItem (
+data class OrderItem(
     val id: UUID?,
     val lessonItemId: LessonItemId,
     val lessonItem: LessonItem,

--- a/src/main/kotlin/team/mozu/dsm/domain/team/model/Stock.kt
+++ b/src/main/kotlin/team/mozu/dsm/domain/team/model/Stock.kt
@@ -1,6 +1,7 @@
 package team.mozu.dsm.domain.team.model
 
 import team.mozu.dsm.domain.annotation.Aggregate
+import team.mozu.dsm.domain.lesson.model.LessonItemId
 import java.time.LocalDateTime
 import java.util.UUID
 
@@ -8,8 +9,10 @@ import java.util.UUID
 data class Stock(
     val id: UUID?,
     val teamId: UUID,
+    val lessonItemId: LessonItemId,
     val itemName: String,
-    val itemCount: Long,
+    val avgPurchasePrice: Long,
+    val quantity: Int,
     val buyMoney: Long,
     val valProfit: Long,
     val profitNum: Double,

--- a/src/main/kotlin/team/mozu/dsm/domain/team/type/OrderType.kt
+++ b/src/main/kotlin/team/mozu/dsm/domain/team/type/OrderType.kt
@@ -1,0 +1,6 @@
+package team.mozu.dsm.domain.team.type
+
+enum class OrderType {
+    BUY,
+    SELL
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

#51 
## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

* 기존 erd 변수명을 수정하였습니다
> `orderDiv` -> `OrderType`
> `orderCnt` -> `orderCount`
> `orderItemMoney` -> `itemPrice`
>  `orderTotMoney` -> `totalAmount`

* 기존 erd orderDiv의 타입인 Boolean은 의미가 모호해 Enum을 생성해 Type을 관리하는 것이 좋을 것 같아 수정
### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
* 변수명이 적절한 지 확인부탁드립니다
* 더 좋은 의견이 있다면 자유롭게 리뷰해주세요!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신기능**
  - 주문 항목(OrderItem) 도입: 주문 타입(BUY/SELL), 품명, 수량, 단가·총액, 재고수 등 엔티티·도메인·매퍼·리포지토리로 CRUD 및 변환 지원.
  - 복합 식별자(LessonItemId) 기반 주문·재고 연동 지원.

- **리팩터링**
  - 재고(Stock) 모델 개편: avgPurchasePrice 및 quantity 필드 추가, 레슨-아이템 복합 식별자 연동으로 관계 구조 변경.
  - 레슨 아이템 도메인: 식별자 통합 및 라운드별 자금 추적 필드 확장.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->