### PR TITLE
Fix/mzbe 111 reissue organ token

### DIFF
--- a/src/main/kotlin/team/mozu/dsm/adapter/in/organ/OrganWebAdapter.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/in/organ/OrganWebAdapter.kt
@@ -36,6 +36,7 @@ class OrganWebAdapter(
         request: ReissueOrganTokenRequest
     ): TokenResponse {
         return reissueOrganTokenUseCase.reissue(request)
+    }
 
     @PostMapping("/login")
     @ResponseStatus(HttpStatus.OK)

--- a/src/main/kotlin/team/mozu/dsm/adapter/in/organ/OrganWebAdapter.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/in/organ/OrganWebAdapter.kt
@@ -16,7 +16,7 @@ import team.mozu.dsm.domain.organ.model.Organ
 @RequestMapping("/organ")
 class OrganWebAdapter(
     private val createOrganUseCase: CreateOrganUseCase,
-    private val reissueOrganTokenUseCase: ReissueOrganTokenUseCase
+    private val reissueOrganTokenUseCase: ReissueOrganTokenUseCase,
     private val loginOrganUseCase: LoginOrganUseCase
 ) {
 

--- a/src/main/kotlin/team/mozu/dsm/adapter/out/auth/persistence/RefreshTokenPersistenceAdapter.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/out/auth/persistence/RefreshTokenPersistenceAdapter.kt
@@ -15,7 +15,7 @@ class RefreshTokenPersistenceAdapter(
         return refreshTokenRepository.findByRefreshToken(refreshToken)
     }
 
-    override fun deleteToken(refreshToken: String): RefreshTokenRedisEntity? {
-        return refreshTokenRepository.deleteToken(refreshToken)
+    override fun deleteByRefreshToken(refreshToken: String): RefreshTokenRedisEntity? {
+        return refreshTokenRepository.deleteByRefreshToken(refreshToken)
     }
 }

--- a/src/main/kotlin/team/mozu/dsm/adapter/out/auth/persistence/repository/RefreshTokenRepository.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/out/auth/persistence/repository/RefreshTokenRepository.kt
@@ -7,5 +7,5 @@ interface RefreshTokenRepository : CrudRepository<RefreshTokenRedisEntity, Strin
 
     fun findByRefreshToken(refreshToken: String): RefreshTokenRedisEntity?
 
-    fun deleteToken(refreshToken: String): RefreshTokenRedisEntity?
+    fun deleteByRefreshToken(refreshToken: String): RefreshTokenRedisEntity?
 }

--- a/src/main/kotlin/team/mozu/dsm/application/port/out/auth/CommandTokenPort.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/port/out/auth/CommandTokenPort.kt
@@ -4,5 +4,5 @@ import team.mozu.dsm.adapter.out.auth.entity.RefreshTokenRedisEntity
 
 interface CommandTokenPort {
 
-    fun deleteToken(refreshToken: String): RefreshTokenRedisEntity?
+    fun deleteByRefreshToken(refreshToken: String): RefreshTokenRedisEntity?
 }

--- a/src/main/kotlin/team/mozu/dsm/application/service/organ/ReissueOrganTokenService.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/service/organ/ReissueOrganTokenService.kt
@@ -20,7 +20,7 @@ class ReissueOrganTokenService(
         val refreshToken = queryTokenPort.findByRefreshToken(request.refreshToken)
             ?: throw RefreshTokenNotFoundException
 
-        commandTokenPort.deleteToken(request.refreshToken)
+        commandTokenPort.deleteByRefreshToken(request.refreshToken)
 
         return jwtPort.createToken(refreshToken.organCode)
     }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #66 

## 📝작업 내용

> 기관 토큰 재발급에서 RefreshTokenNotFound 에러를 해결하였습니다
> deleteToken메서드 이름을 deleteByRefreshToken으로 변경해서 해결했습니다

### 
<img width="1776" height="1314" alt="image" src="https://github.com/user-attachments/assets/f2222595-d4b8-4104-a51d-ad4a27e9ad20" />


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 해당 없음
- 버그 수정
  - 드물게 빌드 실패를 유발할 수 있던 구문 오류를 수정하여 안정성을 향상했습니다.
- 리팩터링
  - 인증 토큰 삭제 동작의 명명과 흐름을 일관되게 정리해 가독성과 유지보수성을 개선했습니다.
  - 관련 계층 간 호출을 통일해 예측 가능성을 높였습니다.
- 기타
  - 내부 표기 일관화로 코드 품질을 개선했습니다. 사용자 기능 변화는 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->