### PR TITLE
Merge/mzbe 98 create lesson

### DIFF
--- a/src/main/kotlin/team/mozu/dsm/adapter/in/lesson/LessonWebAdapter.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/in/lesson/LessonWebAdapter.kt
@@ -1,0 +1,28 @@
+package team.mozu.dsm.adapter.`in`.lesson
+
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+import team.mozu.dsm.adapter.`in`.lesson.dto.request.LessonRequest
+import team.mozu.dsm.adapter.`in`.lesson.dto.response.LessonResponse
+import team.mozu.dsm.application.port.`in`.lesson.CreateLessonUseCase
+
+@RestController
+@RequestMapping("/lesson")
+class LessonWebAdapter(
+    private val createLessonUseCase: CreateLessonUseCase
+) {
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    fun create(
+        @RequestBody @Valid
+        request: LessonRequest
+    ): LessonResponse {
+        return createLessonUseCase.create(request)
+    }
+}

--- a/src/main/kotlin/team/mozu/dsm/adapter/in/lesson/dto/request/LessonRequest.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/in/lesson/dto/request/LessonRequest.kt
@@ -1,0 +1,40 @@
+package team.mozu.dsm.adapter.`in`.lesson.dto.request
+
+import jakarta.validation.constraints.Max
+import jakarta.validation.constraints.Min
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
+import java.util.UUID
+
+// 수업 생성, 수정 API에서 공통 사용
+data class LessonRequest(
+    @field:NotBlank(message = "수업 이름은 필수 입력입니다.")
+    @field:Size(min = 1, max = 30, message = "수업 이름은 1~30자 이내로 입력해주세요.")
+    val lessonName: String,
+
+    @field:Min(100_000, message = "기초 자산은 최소 100,000원 이상 입력해야 합니다.")
+    @field:Max(100_000_000_000_000, message = "기초 자산은 100,000,000,000,000원 이하로 입력해야 합니다.")
+    val baseMoney: Long,
+
+    @field:Min(3, message = "투자 차수는 최소 3차부터 가능합니다.")
+    @field:Max(5, message = "투자 차수는 최대 5차까지 가능합니다.")
+    val lessonRound: Int,
+
+    @field:Size(min = 1, max = 20, message = "수업 종목은 1~20개 사이로 입력해야 합니다.")
+    val lessonItems: List<LessonItemRequest>,
+
+    @field:Size(min = 1, message = "수업 기사는 최소 1개 이상 입력해야 합니다.")
+    val lessonArticles: List<LessonArticleRequest>
+)
+
+data class LessonItemRequest(
+    val id: UUID,
+    val money: List<Int>
+)
+
+data class LessonArticleRequest(
+    val investmentRound: Int,
+
+    @field:Size(max = 20, message = "차수마다 기사는 최대 20개까지 입력할 수 있습니다.")
+    val articles: List<UUID>
+)

--- a/src/main/kotlin/team/mozu/dsm/adapter/in/lesson/dto/response/LessonResponse.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/in/lesson/dto/response/LessonResponse.kt
@@ -1,0 +1,37 @@
+package team.mozu.dsm.adapter.`in`.lesson.dto.response
+
+import com.fasterxml.jackson.annotation.JsonFormat
+import java.time.LocalDateTime
+import java.util.UUID
+
+// 수업 생성, 수정 API에서 공통 사용
+data class LessonResponse(
+    val id: UUID,
+    val name: String,
+    val maxInvRound: Int,
+    val curInvRound: Int? = null,
+    val baseMoney: Long,
+    val lessonNum: String? = null,
+    val isStarred: Boolean,
+    val isDeleted: Boolean,
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+    val createdAt: LocalDateTime,
+    val lessonArticles: List<LessonArticleResponse>,
+    val lessonItems: List<LessonItemResponse>
+)
+
+data class LessonArticleResponse(
+    val investmentRound: Int,
+    val articles: List<ArticleResponse>
+)
+
+data class ArticleResponse(
+    val articleId: UUID,
+    val title: String
+)
+
+data class LessonItemResponse(
+    val itemId: UUID,
+    val itemName: String,
+    val money: List<Int>
+)

--- a/src/main/kotlin/team/mozu/dsm/adapter/in/team/TeamWebAdapter.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/in/team/TeamWebAdapter.kt
@@ -19,7 +19,10 @@ class TeamWebAdapter(
 ) {
     @PostMapping("/participate")
     @ResponseStatus(HttpStatus.CREATED)
-    fun participate(@Valid @RequestBody request: TeamParticipationRequest): TeamTokenResponse {
+    fun participate(
+        @Valid @RequestBody
+        request: TeamParticipationRequest
+    ): TeamTokenResponse {
         val command = TeamParticipationCommand(
             lessonNum = request.lessonNum,
             schoolName = request.schoolName,

--- a/src/main/kotlin/team/mozu/dsm/adapter/out/article/persistence/ArticlePersistenceAdapter.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/out/article/persistence/ArticlePersistenceAdapter.kt
@@ -1,0 +1,27 @@
+package team.mozu.dsm.adapter.out.article.persistence
+
+import org.springframework.stereotype.Component
+import team.mozu.dsm.adapter.out.article.persistence.mapper.ArticleMapper
+import team.mozu.dsm.adapter.out.article.persistence.repository.ArticleRepository
+import team.mozu.dsm.application.port.out.article.QueryArticlePort
+import team.mozu.dsm.domain.article.model.Article
+import java.util.*
+
+@Component
+class ArticlePersistenceAdapter(
+    private val articleRepository: ArticleRepository,
+    private val articleMapper: ArticleMapper
+) : QueryArticlePort {
+
+    //--Query--//
+    override fun existsById(id: UUID): Boolean {
+        return articleRepository.existsById(id)
+    }
+
+    override fun findAllByIds(ids: List<UUID>): List<Article> {
+        return articleRepository.findAllById(ids)
+            .map { articleMapper.toModel(it) }
+    }
+
+    //--Command--//
+}

--- a/src/main/kotlin/team/mozu/dsm/adapter/out/item/persistence/ItemPersistenceAdapter.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/out/item/persistence/ItemPersistenceAdapter.kt
@@ -1,0 +1,27 @@
+package team.mozu.dsm.adapter.out.item.persistence
+
+import org.springframework.stereotype.Component
+import team.mozu.dsm.adapter.out.item.persistence.mapper.ItemMapper
+import team.mozu.dsm.adapter.out.item.persistence.repository.ItemRepository
+import team.mozu.dsm.application.port.out.item.QueryItemPort
+import team.mozu.dsm.domain.item.model.Item
+import java.util.UUID
+
+@Component
+class ItemPersistenceAdapter(
+    private val itemRepository: ItemRepository,
+    private val itemMapper: ItemMapper
+) : QueryItemPort {
+
+    //--Query--//
+    override fun existsById(id: UUID): Boolean {
+        return itemRepository.existsById(id)
+    }
+
+    override fun findAllByIds(ids: List<UUID>): List<Item> {
+        return itemRepository.findAllById(ids)
+            .map { itemMapper.toModel(it) }
+    }
+
+    //--Command--//
+}

--- a/src/main/kotlin/team/mozu/dsm/adapter/out/lesson/entity/LessonItemJpaEntity.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/out/lesson/entity/LessonItemJpaEntity.kt
@@ -42,11 +42,5 @@ class LessonItemJpaEntity(
 
     var round4Money: Int?,
 
-    var round5Money: Int?,
-
-    var round6Money: Int?,
-
-    var round7Money: Int?,
-
-    var round8Money: Int?
+    var round5Money: Int?
 )

--- a/src/main/kotlin/team/mozu/dsm/adapter/out/lesson/entity/LessonJpaEntity.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/out/lesson/entity/LessonJpaEntity.kt
@@ -23,7 +23,7 @@ class LessonJpaEntity(
     var curInvRound: Int,
 
     @Column(nullable = false)
-    var baseMoney: Int,
+    var baseMoney: Long,
 
     @Column(nullable = false, unique = true, columnDefinition = "VARCHAR(10)")
     var lessonNum: String,

--- a/src/main/kotlin/team/mozu/dsm/adapter/out/lesson/entity/LessonJpaEntity.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/out/lesson/entity/LessonJpaEntity.kt
@@ -26,7 +26,7 @@ class LessonJpaEntity(
     var baseMoney: Long,
 
     @Column(unique = true, columnDefinition = "VARCHAR(10)")
-    var lessonNum: String,
+    var lessonNum: String?,
 
     @Column(nullable = false)
     var isStarred: Boolean = false,

--- a/src/main/kotlin/team/mozu/dsm/adapter/out/lesson/entity/LessonJpaEntity.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/out/lesson/entity/LessonJpaEntity.kt
@@ -25,7 +25,7 @@ class LessonJpaEntity(
     @Column(nullable = false)
     var baseMoney: Long,
 
-    @Column(nullable = false, unique = true, columnDefinition = "VARCHAR(10)")
+    @Column(unique = true, columnDefinition = "VARCHAR(10)")
     var lessonNum: String,
 
     @Column(nullable = false)

--- a/src/main/kotlin/team/mozu/dsm/adapter/out/lesson/entity/id/LessonArticleId.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/out/lesson/entity/id/LessonArticleId.kt
@@ -6,6 +6,6 @@ import java.util.UUID
 
 @Embeddable
 data class LessonArticleId(
-    var lessonId: UUID,
-    var articleId: UUID
+    val lessonId: UUID,
+    val articleId: UUID
 ) : Serializable

--- a/src/main/kotlin/team/mozu/dsm/adapter/out/lesson/entity/id/LessonItemId.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/out/lesson/entity/id/LessonItemId.kt
@@ -6,6 +6,6 @@ import java.util.UUID
 
 @Embeddable
 data class LessonItemId(
-    var lessonId: UUID,
-    var itemId: UUID
+    val lessonId: UUID,
+    val itemId: UUID
 ) : Serializable

--- a/src/main/kotlin/team/mozu/dsm/adapter/out/lesson/persistence/LessonArticlePersistenceAdapter.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/out/lesson/persistence/LessonArticlePersistenceAdapter.kt
@@ -1,0 +1,50 @@
+package team.mozu.dsm.adapter.out.lesson.persistence
+
+import org.springframework.stereotype.Component
+import team.mozu.dsm.adapter.out.article.persistence.repository.ArticleRepository
+import team.mozu.dsm.adapter.out.lesson.persistence.mapper.LessonArticleMapper
+import team.mozu.dsm.adapter.out.lesson.persistence.repository.LessonArticleRepository
+import team.mozu.dsm.adapter.out.lesson.persistence.repository.LessonRepository
+import team.mozu.dsm.application.exception.article.ArticleNotFoundException
+import team.mozu.dsm.application.exception.lesson.LessonNotFoundException
+import team.mozu.dsm.application.port.out.lesson.CommandLessonArticlePort
+import team.mozu.dsm.domain.lesson.model.LessonArticle
+import java.util.UUID
+
+@Component
+class LessonArticlePersistenceAdapter(
+    private val lessonRepository: LessonRepository,
+    private val articleRepository: ArticleRepository,
+    private val lessonArticleMapper: LessonArticleMapper,
+    private val lessonArticleRepository: LessonArticleRepository
+) : CommandLessonArticlePort {
+
+    //--Query--//
+
+    //--Command--//
+    override fun saveAll(id: UUID, lessonArticles: List<LessonArticle>): List<LessonArticle> {
+        val lessonEntity = lessonRepository.findById(id)
+            .orElseThrow { LessonNotFoundException }
+
+        /**
+         * LessonArticleList 저장 프로세스
+         * 1) lessonArticles에서 모든 articleId 추출 후 DB에서 한 번에 조회 (DB 성능 최적화를 위해)
+         * 2) .associateBy를 사용하여 Map<UUID, ArticleJpaEntity> 형식으로 변환
+         * 3) 각 LessonArticle 도메인 모델을 Lesson, Article과 매핑하여 JPA 엔티티 생성
+         * 4) 생성된 엔티티를 saveAll로 저장 후 도메인 모델로 변환
+         **/
+        val lessonArticleList = articleRepository.findAllById(lessonArticles.map { it.lessonArticleId.articleId })
+            .associateBy { it.id }
+            .let { articleMap ->
+                lessonArticles.map { model ->
+                    val articleEntity = articleMap[model.lessonArticleId.articleId]
+                        ?: throw ArticleNotFoundException
+
+                    lessonArticleMapper.toEntity(model, lessonEntity, articleEntity)
+                }
+            }
+        lessonArticleRepository.saveAll(lessonArticleList)
+
+        return lessonArticleList.map { entity -> lessonArticleMapper.toModel(entity) }
+    }
+}

--- a/src/main/kotlin/team/mozu/dsm/adapter/out/lesson/persistence/LessonPersistenceAdapter.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/out/lesson/persistence/LessonPersistenceAdapter.kt
@@ -7,10 +7,11 @@ import team.mozu.dsm.application.port.out.lesson.LessonQueryPort
 import team.mozu.dsm.domain.lesson.model.Lesson
 
 @Component
-class LessonQueryPersistenceAdapter(
+class LessonPersistenceAdapter(
     private val lessonRepository: LessonRepository,
     private val lessonMapper: LessonMapper
 ) : LessonQueryPort {
+
     override fun findByLessonNum(lessonNum: String): Lesson? {
         return lessonRepository.findByLessonNum(lessonNum)
             ?.let { lessonMapper.toModel(it) }

--- a/src/main/kotlin/team/mozu/dsm/adapter/out/lesson/persistence/LessonPersistenceAdapter.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/out/lesson/persistence/LessonPersistenceAdapter.kt
@@ -3,17 +3,33 @@ package team.mozu.dsm.adapter.out.lesson.persistence
 import org.springframework.stereotype.Component
 import team.mozu.dsm.adapter.out.lesson.persistence.mapper.LessonMapper
 import team.mozu.dsm.adapter.out.lesson.persistence.repository.LessonRepository
+import team.mozu.dsm.adapter.out.organ.persistence.repository.OrganRepository
+import team.mozu.dsm.application.exception.organ.OrganNotFoundException
+import team.mozu.dsm.application.port.out.lesson.CommandLessonPort
 import team.mozu.dsm.application.port.out.lesson.QueryLessonPort
 import team.mozu.dsm.domain.lesson.model.Lesson
 
 @Component
 class LessonPersistenceAdapter(
     private val lessonRepository: LessonRepository,
-    private val lessonMapper: LessonMapper
-) : QueryLessonPort {
+    private val lessonMapper: LessonMapper,
+    private val organRepository: OrganRepository
+) : QueryLessonPort, CommandLessonPort {
 
+    //--Query--//
     override fun findByLessonNum(lessonNum: String): Lesson? {
         return lessonRepository.findByLessonNum(lessonNum)
             ?.let { lessonMapper.toModel(it) }
+    }
+
+    //--Command--//
+    override fun save(lesson: Lesson): Lesson {
+        val organ = organRepository.findById(lesson.organId)
+            .orElseThrow { OrganNotFoundException }
+
+        val entity = lessonMapper.toEntity(lesson, organ)
+        lessonRepository.save(entity)
+
+        return lessonMapper.toModel(entity)
     }
 }

--- a/src/main/kotlin/team/mozu/dsm/adapter/out/lesson/persistence/LessonPersistenceAdapter.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/out/lesson/persistence/LessonPersistenceAdapter.kt
@@ -3,14 +3,14 @@ package team.mozu.dsm.adapter.out.lesson.persistence
 import org.springframework.stereotype.Component
 import team.mozu.dsm.adapter.out.lesson.persistence.mapper.LessonMapper
 import team.mozu.dsm.adapter.out.lesson.persistence.repository.LessonRepository
-import team.mozu.dsm.application.port.out.lesson.LessonQueryPort
+import team.mozu.dsm.application.port.out.lesson.QueryLessonPort
 import team.mozu.dsm.domain.lesson.model.Lesson
 
 @Component
 class LessonPersistenceAdapter(
     private val lessonRepository: LessonRepository,
     private val lessonMapper: LessonMapper
-) : LessonQueryPort {
+) : QueryLessonPort {
 
     override fun findByLessonNum(lessonNum: String): Lesson? {
         return lessonRepository.findByLessonNum(lessonNum)

--- a/src/main/kotlin/team/mozu/dsm/adapter/out/lesson/persistence/mapper/LessonArticleMapper.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/out/lesson/persistence/mapper/LessonArticleMapper.kt
@@ -1,7 +1,6 @@
 package team.mozu.dsm.adapter.out.lesson.persistence.mapper
 
 import org.mapstruct.Mapper
-import org.mapstruct.Mapping
 import team.mozu.dsm.adapter.out.article.entity.ArticleJpaEntity
 import team.mozu.dsm.adapter.out.lesson.entity.LessonArticleJpaEntity
 import team.mozu.dsm.adapter.out.lesson.entity.LessonJpaEntity
@@ -11,13 +10,14 @@ import team.mozu.dsm.domain.lesson.model.LessonArticle
 @Mapper(componentModel = "spring")
 abstract class LessonArticleMapper {
 
-    @Mapping(target = "lessonId", source = "lesson.id")
-    @Mapping(target = "articleId", source = "article.id")
     abstract fun toModel(entity: LessonArticleJpaEntity): LessonArticle
 
     fun toEntity(model: LessonArticle, lesson: LessonJpaEntity, article: ArticleJpaEntity): LessonArticleJpaEntity {
         return LessonArticleJpaEntity(
-            lessonArticleId = LessonArticleId(model.lessonId, model.articleId),
+            lessonArticleId = LessonArticleId(
+                model.lessonArticleId.lessonId,
+                model.lessonArticleId.articleId
+            ),
             lesson = lesson,
             article = article,
             investmentRound = model.investmentRound

--- a/src/main/kotlin/team/mozu/dsm/adapter/out/lesson/persistence/mapper/LessonItemMapper.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/out/lesson/persistence/mapper/LessonItemMapper.kt
@@ -1,7 +1,6 @@
 package team.mozu.dsm.adapter.out.lesson.persistence.mapper
 
 import org.mapstruct.Mapper
-import org.mapstruct.Mapping
 import team.mozu.dsm.adapter.out.item.entity.ItemJpaEntity
 import team.mozu.dsm.adapter.out.lesson.entity.LessonItemJpaEntity
 import team.mozu.dsm.adapter.out.lesson.entity.LessonJpaEntity
@@ -11,7 +10,6 @@ import team.mozu.dsm.domain.lesson.model.LessonItem
 @Mapper(componentModel = "spring")
 abstract class LessonItemMapper {
 
-    @Mapping(target = "lessonItemId", source = "lessonItemId")
     abstract fun toModel(entity: LessonItemJpaEntity): LessonItem
 
     fun toEntity(model: LessonItem, lesson: LessonJpaEntity, item: ItemJpaEntity): LessonItemJpaEntity {

--- a/src/main/kotlin/team/mozu/dsm/adapter/out/lesson/persistence/mapper/LessonItemMapper.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/out/lesson/persistence/mapper/LessonItemMapper.kt
@@ -27,10 +27,7 @@ abstract class LessonItemMapper {
             round2Money = model.round2Money,
             round3Money = model.round3Money,
             round4Money = model.round4Money,
-            round5Money = model.round5Money,
-            round6Money = model.round6Money,
-            round7Money = model.round7Money,
-            round8Money = model.round8Money
+            round5Money = model.round5Money
         )
     }
 }

--- a/src/main/kotlin/team/mozu/dsm/adapter/out/organ/persistence/OrganPersistenceAdapter.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/out/organ/persistence/OrganPersistenceAdapter.kt
@@ -13,10 +13,12 @@ class OrganPersistenceAdapter(
     private val organMapper: OrganMapper
 ) : QueryOrganPort, CommandOrganPort {
 
+    //--Query--//
     override fun findByOrganCode(organCode: String): Organ? {
         return organRepository.findByOrganCode(organCode)?.let { organMapper.toModel(it) }
     }
 
+    //--Command--//
     override fun save(organ: Organ): Organ {
         val organ = organMapper.toEntity(organ)
         val savedOrgan = organRepository.save(organ)

--- a/src/main/kotlin/team/mozu/dsm/adapter/out/sse/SsePersistenceAdapter.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/out/sse/SsePersistenceAdapter.kt
@@ -17,6 +17,7 @@ class SsePersistenceAdapter(
         private const val DEFAULT_TIMEOUT = 60L * 1000 * 60
     }
 
+    //--Subscribe--//
     override fun subscribe(clientId: String): SseEmitter {
         val emitter = SseEmitter(DEFAULT_TIMEOUT)
         sseEmitterRepository.save(clientId, emitter)
@@ -27,6 +28,7 @@ class SsePersistenceAdapter(
         return emitter
     }
 
+    //--Publish--//
     override fun publishTo(clientId: String, eventName: String, data: Any) {
         sseEmitterRepository.get(clientId)?.let { emitter ->
             try {

--- a/src/main/kotlin/team/mozu/dsm/adapter/out/team/persistence/TeamPersistenceAdapter.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/out/team/persistence/TeamPersistenceAdapter.kt
@@ -15,6 +15,9 @@ class TeamPersistenceAdapter(
     private val teamMapper: TeamMapper
 ) : TeamCommandPort {
 
+    //--Query--//
+
+    //--Command--//
     override fun save(team: Team): Team {
         val lessonEntity = lessonRepository.findById(team.lessonId)
             .orElseThrow { LessonNotFoundException }

--- a/src/main/kotlin/team/mozu/dsm/adapter/out/team/persistence/TeamPersistenceAdapter.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/out/team/persistence/TeamPersistenceAdapter.kt
@@ -9,11 +9,12 @@ import team.mozu.dsm.application.port.out.team.TeamCommandPort
 import team.mozu.dsm.domain.team.model.Team
 
 @Component
-class TeamCommandPersistenceAdapter(
+class TeamPersistenceAdapter(
     private val teamRepository: TeamRepository,
     private val lessonRepository: LessonRepository,
     private val teamMapper: TeamMapper
 ) : TeamCommandPort {
+
     override fun save(team: Team): Team {
         val lessonEntity = lessonRepository.findById(team.lessonId)
             .orElseThrow { LessonNotFoundException }

--- a/src/main/kotlin/team/mozu/dsm/application/exception/article/ArticleNotFoundException.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/exception/article/ArticleNotFoundException.kt
@@ -1,0 +1,6 @@
+package team.mozu.dsm.application.exception.article
+
+import team.mozu.dsm.global.error.exception.ErrorCode
+import team.mozu.dsm.global.error.exception.MozuException
+
+object ArticleNotFoundException : MozuException(ErrorCode.ARTICLE_NOT_FOUND)

--- a/src/main/kotlin/team/mozu/dsm/application/exception/item/ItemNotFoundException.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/exception/item/ItemNotFoundException.kt
@@ -1,0 +1,6 @@
+package team.mozu.dsm.application.exception.item
+
+import team.mozu.dsm.global.error.exception.ErrorCode
+import team.mozu.dsm.global.error.exception.MozuException
+
+object ItemNotFoundException : MozuException(ErrorCode.ITEM_NOT_FOUND)

--- a/src/main/kotlin/team/mozu/dsm/application/port/in/lesson/CreateLessonUseCase.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/port/in/lesson/CreateLessonUseCase.kt
@@ -1,0 +1,9 @@
+package team.mozu.dsm.application.port.`in`.lesson
+
+import team.mozu.dsm.adapter.`in`.lesson.dto.request.LessonRequest
+import team.mozu.dsm.adapter.`in`.lesson.dto.response.LessonResponse
+
+interface CreateLessonUseCase {
+
+    fun create(request: LessonRequest): LessonResponse
+}

--- a/src/main/kotlin/team/mozu/dsm/application/port/in/team/dto/request/TeamParticipationCommand.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/port/in/team/dto/request/TeamParticipationCommand.kt
@@ -2,7 +2,7 @@ package team.mozu.dsm.application.port.`in`.team.dto.request
 
 import jakarta.validation.constraints.NotBlank
 
-data class TeamParticipationCommand (
+data class TeamParticipationCommand(
     @field:NotBlank(message = "lessonNum은 필수입니다")
     val lessonNum: String,
     @field:NotBlank(message = "schoolName은 필수입니다")

--- a/src/main/kotlin/team/mozu/dsm/application/port/in/team/dto/response/TeamToken.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/port/in/team/dto/response/TeamToken.kt
@@ -2,7 +2,7 @@ package team.mozu.dsm.application.port.`in`.team.dto.response
 
 import java.time.LocalDateTime
 
-data class TeamToken (
+data class TeamToken(
     val accessToken: String,
     val accessExpiredAt: LocalDateTime
 )

--- a/src/main/kotlin/team/mozu/dsm/application/port/out/article/QueryArticlePort.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/port/out/article/QueryArticlePort.kt
@@ -1,0 +1,11 @@
+package team.mozu.dsm.application.port.out.article
+
+import team.mozu.dsm.domain.article.model.Article
+import java.util.UUID
+
+interface QueryArticlePort {
+
+    fun existsById(id: UUID): Boolean
+
+    fun findAllByIds(ids: List<UUID>): List<Article>
+}

--- a/src/main/kotlin/team/mozu/dsm/application/port/out/auth/JwtPort.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/port/out/auth/JwtPort.kt
@@ -3,7 +3,6 @@ package team.mozu.dsm.application.port.out.auth
 import jakarta.servlet.http.HttpServletRequest
 import org.springframework.security.core.Authentication
 import team.mozu.dsm.adapter.`in`.auth.dto.response.TokenResponse
-import team.mozu.dsm.adapter.`in`.team.dto.response.TeamTokenResponse
 import team.mozu.dsm.application.port.`in`.team.dto.response.TeamToken
 
 interface JwtPort {

--- a/src/main/kotlin/team/mozu/dsm/application/port/out/auth/SecurityPort.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/port/out/auth/SecurityPort.kt
@@ -1,0 +1,8 @@
+package team.mozu.dsm.application.port.out.auth
+
+import team.mozu.dsm.domain.organ.model.Organ
+
+interface SecurityPort {
+
+    fun getCurrentOrgan(): Organ
+}

--- a/src/main/kotlin/team/mozu/dsm/application/port/out/item/QueryItemPort.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/port/out/item/QueryItemPort.kt
@@ -1,0 +1,11 @@
+package team.mozu.dsm.application.port.out.item
+
+import team.mozu.dsm.domain.item.model.Item
+import java.util.UUID
+
+interface QueryItemPort {
+
+    fun existsById(id: UUID): Boolean
+
+    fun findAllByIds(ids: List<UUID>): List<Item>
+}

--- a/src/main/kotlin/team/mozu/dsm/application/port/out/lesson/CommandLessonArticlePort.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/port/out/lesson/CommandLessonArticlePort.kt
@@ -1,0 +1,9 @@
+package team.mozu.dsm.application.port.out.lesson
+
+import team.mozu.dsm.domain.lesson.model.LessonArticle
+import java.util.UUID
+
+interface CommandLessonArticlePort {
+
+    fun saveAll(id: UUID, lessonArticles: List<LessonArticle>): List<LessonArticle>
+}

--- a/src/main/kotlin/team/mozu/dsm/application/port/out/lesson/CommandLessonItemPort.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/port/out/lesson/CommandLessonItemPort.kt
@@ -1,0 +1,9 @@
+package team.mozu.dsm.application.port.out.lesson
+
+import team.mozu.dsm.domain.lesson.model.LessonItem
+import java.util.UUID
+
+interface CommandLessonItemPort {
+
+    fun saveAll(id: UUID, lessonItems: List<LessonItem>): List<LessonItem>
+}

--- a/src/main/kotlin/team/mozu/dsm/application/port/out/lesson/CommandLessonPort.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/port/out/lesson/CommandLessonPort.kt
@@ -1,0 +1,8 @@
+package team.mozu.dsm.application.port.out.lesson
+
+import team.mozu.dsm.domain.lesson.model.Lesson
+
+interface CommandLessonPort {
+
+    fun save(lesson: Lesson): Lesson
+}

--- a/src/main/kotlin/team/mozu/dsm/application/port/out/lesson/QueryLessonPort.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/port/out/lesson/QueryLessonPort.kt
@@ -2,7 +2,7 @@ package team.mozu.dsm.application.port.out.lesson
 
 import team.mozu.dsm.domain.lesson.model.Lesson
 
-interface LessonQueryPort {
+interface QueryLessonPort {
 
     fun findByLessonNum(lessonNum: String): Lesson?
 }

--- a/src/main/kotlin/team/mozu/dsm/application/service/lesson/CreateLessonService.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/service/lesson/CreateLessonService.kt
@@ -1,0 +1,149 @@
+package team.mozu.dsm.application.service.lesson
+
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import team.mozu.dsm.adapter.`in`.lesson.dto.request.LessonRequest
+import team.mozu.dsm.adapter.`in`.lesson.dto.response.ArticleResponse
+import team.mozu.dsm.adapter.`in`.lesson.dto.response.LessonArticleResponse
+import team.mozu.dsm.adapter.`in`.lesson.dto.response.LessonItemResponse
+import team.mozu.dsm.adapter.`in`.lesson.dto.response.LessonResponse
+import team.mozu.dsm.application.exception.article.ArticleNotFoundException
+import team.mozu.dsm.application.exception.item.ItemNotFoundException
+import team.mozu.dsm.application.port.`in`.lesson.CreateLessonUseCase
+import team.mozu.dsm.application.port.out.article.QueryArticlePort
+import team.mozu.dsm.application.port.out.auth.SecurityPort
+import team.mozu.dsm.application.port.out.item.QueryItemPort
+import team.mozu.dsm.application.port.out.lesson.CommandLessonArticlePort
+import team.mozu.dsm.application.port.out.lesson.CommandLessonItemPort
+import team.mozu.dsm.application.port.out.lesson.CommandLessonPort
+import team.mozu.dsm.domain.lesson.model.Lesson
+import team.mozu.dsm.domain.lesson.model.LessonArticle
+import team.mozu.dsm.domain.lesson.model.LessonItem
+import team.mozu.dsm.domain.lesson.model.id.LessonArticleId
+import team.mozu.dsm.domain.lesson.model.id.LessonItemId
+
+@Service
+class CreateLessonService(
+    private val securityPort: SecurityPort,
+    private val itemPort: QueryItemPort,
+    private val articlePort: QueryArticlePort,
+    private val lessonPort: CommandLessonPort,
+    private val lessonItemPort: CommandLessonItemPort,
+    private val lessonArticlePort: CommandLessonArticlePort
+) : CreateLessonUseCase {
+
+    @Transactional
+    override fun create(request: LessonRequest): LessonResponse {
+        // 로그인한 기관 정보 조회
+        val organ = securityPort.getCurrentOrgan()
+
+        // 요청된 lessonItems에 해당 종목이 DB에 존재하는지 확인
+        if (request.lessonItems.any { !itemPort.existsById(it.id) }) {
+            throw ItemNotFoundException
+        }
+
+        // 요청된 lessonArticles에 해당 기사가 DB에 존재하는지 확인
+        if (request.lessonArticles.any { lessonArticle ->
+            lessonArticle.articles.any { !articlePort.existsById(it) }
+        }
+        ) {
+            throw ArticleNotFoundException
+        }
+
+        // Lesson 도메인 객체 생성 후 DB에 저장
+        val lesson = Lesson(
+            organId = organ.id!!,
+            lessonName = request.lessonName,
+            maxInvRound = request.lessonRound,
+            curInvRound = 0,
+            baseMoney = request.baseMoney,
+            isStarred = false,
+            isDeleted = false,
+            isInProgress = false
+        )
+        val saved = lessonPort.save(lesson)
+
+        // lessonItems로 LessonItem 도메인으로 변환 후 saveAll로 한 번에 저장
+        val lessonItems = request.lessonItems.map { req ->
+            LessonItem(
+                lessonItemId = LessonItemId(saved.id!!, req.id),
+                currentMoney = req.money.get(0),
+                round1Money = req.money.get(1),
+                round2Money = req.money.get(2),
+                round3Money = req.money.get(3),
+                round4Money = req.money.getOrNull(4),
+                round5Money = req.money.getOrNull(5)
+            )
+        }
+        lessonItemPort.saveAll(saved.id!!, lessonItems)
+
+        // lessonArticles로 LessonArticle 도메인으로 변환 후 saveAll로 한 번에 저장
+        val lessonArticles = request.lessonArticles.flatMap { req ->
+            req.articles.map { article ->
+                LessonArticle(
+                    lessonArticleId = LessonArticleId(saved.id!!, article),
+                    investmentRound = req.investmentRound
+                )
+            }
+        }
+        lessonArticlePort.saveAll(saved.id!!, lessonArticles)
+
+        // 저장된 기사 정보 조회 후 Map 생성 (ID → Article)
+        val articleIds = lessonArticles.map { it.lessonArticleId.articleId }
+        val articleMap = articlePort.findAllByIds(articleIds).associateBy { it.id!! }
+
+        // DTO 변환: 투자 차수별로 기사 묶음 생성
+        val lessonArticleResponses = lessonArticles
+            .groupBy { it.investmentRound }
+            .map { (round, articles) ->
+                LessonArticleResponse(
+                    investmentRound = round,
+                    articles = articles.map { lessonArticle ->
+                        val article = articleMap[lessonArticle.lessonArticleId.articleId]
+                            ?: throw ArticleNotFoundException
+                        ArticleResponse(
+                            articleId = article.id!!,
+                            title = article.articleName
+                        )
+                    }
+                )
+            }
+
+        // 저장된 종목 정보 조회 후 Map 생성 (ID → Item)
+        val itemIds = lessonItems.map { it.lessonItemId.lessonId }
+        val itemMap = itemPort.findAllByIds(itemIds).associateBy { it.id!! }
+
+        // DTO 변환: 금액 리스트 구성 (초기 금액 ~ 3차 + nullable 4 ~ 5차)
+        val lessonItemResponses = lessonItems.map { lessonItem ->
+            val item = itemMap[lessonItem.lessonItemId.itemId]
+                ?: throw ItemNotFoundException
+            LessonItemResponse(
+                itemId = item.id!!,
+                itemName = item.itemName,
+                money = listOf(
+                    lessonItem.currentMoney,
+                    lessonItem.round1Money,
+                    lessonItem.round2Money,
+                    lessonItem.round3Money
+                ).let { list ->
+                    listOfNotNull(*list.toTypedArray(), lessonItem.round4Money, lessonItem.round5Money)
+                }
+            )
+        }
+
+        // 최종 LessonResponse 반환
+        return LessonResponse(
+            id = saved.id,
+            name = saved.lessonName,
+            maxInvRound = saved.maxInvRound,
+            curInvRound = saved.curInvRound,
+            baseMoney = saved.baseMoney,
+            lessonNum = saved.lessonNum,
+            isStarred = saved.isStarred,
+            isDeleted = saved.isDeleted,
+            createdAt = saved.createdAt!!,
+            lessonArticles = lessonArticleResponses,
+            lessonItems = lessonItemResponses
+        )
+    }
+}

--- a/src/main/kotlin/team/mozu/dsm/application/service/team/TeamParticipationService.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/service/team/TeamParticipationService.kt
@@ -5,20 +5,23 @@ import org.springframework.transaction.annotation.Transactional
 import org.springframework.transaction.support.TransactionSynchronization
 import org.springframework.transaction.support.TransactionSynchronizationManager
 import team.mozu.dsm.adapter.`in`.team.dto.TeamParticipationEventDTO
-import team.mozu.dsm.application.exception.lesson.*
+import team.mozu.dsm.application.exception.lesson.LessonDeletedException
+import team.mozu.dsm.application.exception.lesson.LessonNotFoundException
+import team.mozu.dsm.application.exception.lesson.LessonNotInProgressException
+import team.mozu.dsm.application.exception.lesson.LessonNumNotFoundException
 import team.mozu.dsm.application.port.`in`.sse.PublishToAllSseUseCase
-import team.mozu.dsm.application.port.out.auth.JwtPort
-import team.mozu.dsm.application.port.out.lesson.LessonQueryPort
-import team.mozu.dsm.application.port.out.team.TeamCommandPort
 import team.mozu.dsm.application.port.`in`.team.TeamParticipationUseCase
 import team.mozu.dsm.application.port.`in`.team.dto.request.TeamParticipationCommand
 import team.mozu.dsm.application.port.`in`.team.dto.response.TeamToken
+import team.mozu.dsm.application.port.out.auth.JwtPort
+import team.mozu.dsm.application.port.out.lesson.QueryLessonPort
+import team.mozu.dsm.application.port.out.team.TeamCommandPort
 import team.mozu.dsm.domain.team.model.Team
 import java.time.LocalDateTime
 
 @Service
 class TeamParticipationService(
-    private val lessonQueryPort: LessonQueryPort,
+    private val queryLessonPort: QueryLessonPort,
     private val teamCommandPort: TeamCommandPort,
     private val jwtPort: JwtPort,
     private val publishToAllSseUseCase: PublishToAllSseUseCase
@@ -26,7 +29,7 @@ class TeamParticipationService(
 
     @Transactional
     override fun participate(command: TeamParticipationCommand): TeamToken {
-        val lesson = lessonQueryPort.findByLessonNum(command.lessonNum)
+        val lesson = queryLessonPort.findByLessonNum(command.lessonNum)
             ?: throw LessonNumNotFoundException
 
         if (!lesson.isInProgress) {

--- a/src/main/kotlin/team/mozu/dsm/application/service/team/TeamParticipationService.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/service/team/TeamParticipationService.kt
@@ -1,4 +1,4 @@
-package team.mozu.dsm.application.team
+package team.mozu.dsm.application.service.team
 
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional

--- a/src/main/kotlin/team/mozu/dsm/application/service/team/TeamParticipationService.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/service/team/TeamParticipationService.kt
@@ -75,6 +75,6 @@ class TeamParticipationService(
                 }
             }
         )
-        return jwtPort.createStudentAccessToken(lesson.lessonNum)
+        return jwtPort.createStudentAccessToken(lesson.lessonNum!!)
     }
 }

--- a/src/main/kotlin/team/mozu/dsm/domain/lesson/model/Lesson.kt
+++ b/src/main/kotlin/team/mozu/dsm/domain/lesson/model/Lesson.kt
@@ -11,7 +11,7 @@ data class Lesson(
     val lessonName: String,
     val maxInvRound: Int,
     val curInvRound: Int,
-    val baseMoney: Int,
+    val baseMoney: Long,
     val lessonNum: String,
     val isStarred: Boolean,
     val isDeleted: Boolean,

--- a/src/main/kotlin/team/mozu/dsm/domain/lesson/model/Lesson.kt
+++ b/src/main/kotlin/team/mozu/dsm/domain/lesson/model/Lesson.kt
@@ -6,16 +6,16 @@ import java.util.UUID
 
 @Aggregate
 data class Lesson(
-    val id: UUID?,
+    val id: UUID? = null,
     val organId: UUID,
     val lessonName: String,
     val maxInvRound: Int,
     val curInvRound: Int,
     val baseMoney: Long,
-    val lessonNum: String,
+    val lessonNum: String? = null,
     val isStarred: Boolean,
     val isDeleted: Boolean,
     val isInProgress: Boolean,
-    val createdAt: LocalDateTime,
-    val updatedAt: LocalDateTime?
+    val createdAt: LocalDateTime? = null,
+    val updatedAt: LocalDateTime? = null
 )

--- a/src/main/kotlin/team/mozu/dsm/domain/lesson/model/LessonArticle.kt
+++ b/src/main/kotlin/team/mozu/dsm/domain/lesson/model/LessonArticle.kt
@@ -1,9 +1,8 @@
 package team.mozu.dsm.domain.lesson.model
 
-import java.util.UUID
+import team.mozu.dsm.domain.lesson.model.id.LessonArticleId
 
 data class LessonArticle(
-    val lessonId: UUID,
-    val articleId: UUID,
+    val lessonArticleId: LessonArticleId,
     val investmentRound: Int
 )

--- a/src/main/kotlin/team/mozu/dsm/domain/lesson/model/LessonItem.kt
+++ b/src/main/kotlin/team/mozu/dsm/domain/lesson/model/LessonItem.kt
@@ -10,8 +10,5 @@ data class LessonItem(
     val round2Money: Int,
     val round3Money: Int,
     val round4Money: Int?,
-    val round5Money: Int?,
-    val round6Money: Int?,
-    val round7Money: Int?,
-    val round8Money: Int?
+    val round5Money: Int?
 )

--- a/src/main/kotlin/team/mozu/dsm/domain/lesson/model/LessonItem.kt
+++ b/src/main/kotlin/team/mozu/dsm/domain/lesson/model/LessonItem.kt
@@ -1,6 +1,7 @@
 package team.mozu.dsm.domain.lesson.model
 
 import team.mozu.dsm.domain.annotation.Aggregate
+import team.mozu.dsm.domain.lesson.model.id.LessonItemId
 
 @Aggregate
 data class LessonItem(

--- a/src/main/kotlin/team/mozu/dsm/domain/lesson/model/LessonItemId.kt
+++ b/src/main/kotlin/team/mozu/dsm/domain/lesson/model/LessonItemId.kt
@@ -1,8 +1,0 @@
-package team.mozu.dsm.domain.lesson.model
-
-import java.util.UUID
-
-data class LessonItemId(
-    val lessonId: UUID,
-    val itemId: UUID
-)

--- a/src/main/kotlin/team/mozu/dsm/domain/lesson/model/id/LessonArticleId.kt
+++ b/src/main/kotlin/team/mozu/dsm/domain/lesson/model/id/LessonArticleId.kt
@@ -1,0 +1,8 @@
+package team.mozu.dsm.domain.lesson.model.id
+
+import java.util.UUID
+
+data class LessonArticleId(
+    val lessonId: UUID,
+    val articleId: UUID
+)

--- a/src/main/kotlin/team/mozu/dsm/domain/lesson/model/id/LessonItemId.kt
+++ b/src/main/kotlin/team/mozu/dsm/domain/lesson/model/id/LessonItemId.kt
@@ -1,0 +1,8 @@
+package team.mozu.dsm.domain.lesson.model.id
+
+import java.util.UUID
+
+data class LessonItemId(
+    val lessonId: UUID,
+    val itemId: UUID
+)

--- a/src/main/kotlin/team/mozu/dsm/domain/team/model/OrderItem.kt
+++ b/src/main/kotlin/team/mozu/dsm/domain/team/model/OrderItem.kt
@@ -1,7 +1,7 @@
 package team.mozu.dsm.domain.team.model
 
 import team.mozu.dsm.domain.annotation.Aggregate
-import team.mozu.dsm.domain.lesson.model.LessonItemId
+import team.mozu.dsm.domain.lesson.model.id.LessonItemId
 import team.mozu.dsm.domain.team.type.OrderType
 import java.time.LocalDateTime
 import java.util.UUID

--- a/src/main/kotlin/team/mozu/dsm/domain/team/model/Stock.kt
+++ b/src/main/kotlin/team/mozu/dsm/domain/team/model/Stock.kt
@@ -1,7 +1,7 @@
 package team.mozu.dsm.domain.team.model
 
 import team.mozu.dsm.domain.annotation.Aggregate
-import team.mozu.dsm.domain.lesson.model.LessonItemId
+import team.mozu.dsm.domain.lesson.model.id.LessonItemId
 import java.time.LocalDateTime
 import java.util.UUID
 

--- a/src/main/kotlin/team/mozu/dsm/global/config/security/SecurityConfig.kt
+++ b/src/main/kotlin/team/mozu/dsm/global/config/security/SecurityConfig.kt
@@ -44,14 +44,13 @@ class SecurityConfig(
 
                 //user
                 it.requestMatchers("/user/**").permitAll()
-                
+
                 //organ
                 it.requestMatchers(HttpMethod.POST, "/organ/create").permitAll()
-                
+
                 //team
                 it.requestMatchers(HttpMethod.POST, "/team/participate").permitAll()
                     .anyRequest().authenticated()
-
             }
             .with(FilterConfig(jwtTokenProvider, objectMapper), Customizer.withDefaults())
 

--- a/src/main/kotlin/team/mozu/dsm/global/error/exception/ErrorCode.kt
+++ b/src/main/kotlin/team/mozu/dsm/global/error/exception/ErrorCode.kt
@@ -12,6 +12,9 @@ enum class ErrorCode(
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "Invalid Token"),
     UNAUTHORIZED_TOKEN_TYPE(HttpStatus.UNAUTHORIZED, "Unauthorized Token Type"),
 
+    // auth
+    UNAUTHENTICATED(HttpStatus.UNAUTHORIZED, "Authentication Required"),
+
     // s3
     IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "Image Not Found"),
     IMAGE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "Image Upload Failed"),
@@ -33,6 +36,12 @@ enum class ErrorCode(
     LESSON_NOT_IN_PROGRESS(HttpStatus.UNPROCESSABLE_ENTITY, "Lesson Not In Progress"),
     LESSON_DELETED(HttpStatus.BAD_REQUEST, "Lesson Deleted"),
     TEAM_NAME_REQUIRED(HttpStatus.BAD_REQUEST, "Team Name Required"),
+
+    // item
+    ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "Item Not Found"),
+
+    // article
+    ARTICLE_NOT_FOUND(HttpStatus.NOT_FOUND, "Article Not Found"),
 
     // general
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "Bad Request"),

--- a/src/main/kotlin/team/mozu/dsm/global/exception/UnauthenticatedException.kt
+++ b/src/main/kotlin/team/mozu/dsm/global/exception/UnauthenticatedException.kt
@@ -1,0 +1,6 @@
+package team.mozu.dsm.global.exception
+
+import team.mozu.dsm.global.error.exception.ErrorCode
+import team.mozu.dsm.global.error.exception.MozuException
+
+object UnauthenticatedException : MozuException(ErrorCode.UNAUTHENTICATED)

--- a/src/main/kotlin/team/mozu/dsm/global/security/SecurityAdapter.kt
+++ b/src/main/kotlin/team/mozu/dsm/global/security/SecurityAdapter.kt
@@ -1,0 +1,25 @@
+package team.mozu.dsm.global.security
+
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.stereotype.Component
+import team.mozu.dsm.application.exception.organ.OrganNotFoundException
+import team.mozu.dsm.application.port.out.auth.SecurityPort
+import team.mozu.dsm.domain.organ.model.Organ
+import team.mozu.dsm.global.exception.UnauthenticatedException
+import team.mozu.dsm.global.security.auth.CustomUserDetails
+
+@Component
+class SecurityAdapter : SecurityPort {
+
+    override fun getCurrentOrgan(): Organ {
+        val authentication = SecurityContextHolder.getContext().authentication
+            ?: throw UnauthenticatedException
+
+        val principal = authentication.principal
+        if (principal is CustomUserDetails) {
+            return principal.organ // 로그인 시 넣어둔 Organ 꺼내기
+        } else {
+            throw OrganNotFoundException
+        }
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

- #53 

## 📝작업 내용

> 수업 생성 API

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택) !! 꼭 읽어주세요

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
현재 개발한 브랜치는 기관 로그인 API가 머지되기 전에 작업을 시작한 브랜치라, 별도의 테스트를 진행하지 못했습니다..🥲
코드 확인하시면서 문제될만한 부분 있으면 바로 말씀해주시고, 다음 이슈 개발 전에는 해당 API 테스트를 진행하고, PR에 스크린샷에 같이 첨부하겠습니다.

- **Lesson 모델의 createdAt 필드 관련**
기존에는 createdAt 필드가 null일 수 없도록 설정했으나, JPA에서 자동으로 관리해주기 때문에 createLessonService에서 Lesson 엔티티로 변환 후 저장 시 해당 필드를 수동으로 넣을 필요가 없다고 판단했습니다.
다만 not null 설정 시 강제로 값을 지정해야 하는 문제가 있어, 현재는 초기값을 null로 두었습니다.
→ **createLessonService에서 Lesson 객체 생성 시 작성한 주석 확인해주시고 의견 부탁드립니다:)**
- **createLessonService 함수 구조 관련**
현재 create 함수 하나에 많은 로직이 들어가 있다는 점은 인지하고 있습니다.
다만 개발 일정상 우선 동작 위주로 구현했으며, 추후 리팩토링으로 개선할 예정입니다. 이 점 참고하여 리뷰 부탁드립니다!

연관관계가 복잡한 API라 코드가 다소 많을 수 있지만 천천히 읽어봐주시면 감사하겠습니다!!🥹