### PR TITLE
Feature/mzbe 114 query organ detail

### DIFF
--- a/src/main/kotlin/team/mozu/dsm/adapter/in/organ/OrganWebAdapter.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/in/organ/OrganWebAdapter.kt
@@ -51,9 +51,9 @@ class OrganWebAdapter(
         return loginOrganUseCase.login(request)
     }
 
-    @GetMapping("/{organId}")
+    @GetMapping("/{id}")
     @ResponseStatus(HttpStatus.OK)
-    fun queryOrganDetail(@PathVariable organId: UUID): OrganDetailResponse {
-        return queryOrganDetailUseCase.queryOrganDetail(organId)
+    fun queryOrganDetail(@PathVariable id: UUID): OrganDetailResponse {
+        return queryOrganDetailUseCase.queryOrganDetail(id)
     }
 }

--- a/src/main/kotlin/team/mozu/dsm/adapter/in/organ/OrganWebAdapter.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/in/organ/OrganWebAdapter.kt
@@ -8,16 +8,20 @@ import team.mozu.dsm.adapter.`in`.organ.dto.request.CreateOrganRequest
 import team.mozu.dsm.adapter.`in`.organ.dto.request.ReissueOrganTokenRequest
 import team.mozu.dsm.application.port.`in`.organ.ReissueOrganTokenUseCase
 import team.mozu.dsm.adapter.`in`.organ.dto.request.LoginOrganRequest
+import team.mozu.dsm.adapter.`in`.organ.dto.response.OrganDetailResponse
 import team.mozu.dsm.application.port.`in`.organ.CreateOrganUseCase
 import team.mozu.dsm.application.port.`in`.organ.LoginOrganUseCase
+import team.mozu.dsm.application.port.`in`.organ.QueryOrganDetailUseCase
 import team.mozu.dsm.domain.organ.model.Organ
+import java.util.UUID
 
 @RestController
 @RequestMapping("/organ")
 class OrganWebAdapter(
     private val createOrganUseCase: CreateOrganUseCase,
     private val reissueOrganTokenUseCase: ReissueOrganTokenUseCase,
-    private val loginOrganUseCase: LoginOrganUseCase
+    private val loginOrganUseCase: LoginOrganUseCase,
+    private val queryOrganDetailUseCase: QueryOrganDetailUseCase
 ) {
 
     @PostMapping("/create")
@@ -45,5 +49,11 @@ class OrganWebAdapter(
         request: LoginOrganRequest
     ): TokenResponse {
         return loginOrganUseCase.login(request)
+    }
+
+    @GetMapping("/{organId}")
+    @ResponseStatus(HttpStatus.OK)
+    fun queryOrganDetail(@PathVariable organId: UUID): OrganDetailResponse {
+        return queryOrganDetailUseCase.queryOrganDetail(organId)
     }
 }

--- a/src/main/kotlin/team/mozu/dsm/adapter/in/organ/dto/response/OrganDetailResponse.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/in/organ/dto/response/OrganDetailResponse.kt
@@ -1,8 +1,9 @@
 package team.mozu.dsm.adapter.`in`.organ.dto.response
 
+import com.querydsl.core.annotations.QueryProjection
 import java.util.UUID
 
-data class OrganDetailResponse(
+data class OrganDetailResponse @QueryProjection constructor(
     val id: UUID,
     val organCode: String,
     val organName: String,

--- a/src/main/kotlin/team/mozu/dsm/adapter/in/organ/dto/response/OrganDetailResponse.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/in/organ/dto/response/OrganDetailResponse.kt
@@ -1,0 +1,10 @@
+package team.mozu.dsm.adapter.`in`.organ.dto.response
+
+import java.util.UUID
+
+data class OrganDetailResponse(
+    val id: UUID,
+    val organCode: String,
+    val organName: String,
+    val password: String
+)

--- a/src/main/kotlin/team/mozu/dsm/adapter/out/organ/persistence/OrganPersistenceAdapter.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/out/organ/persistence/OrganPersistenceAdapter.kt
@@ -1,17 +1,25 @@
 package team.mozu.dsm.adapter.out.organ.persistence
 
+import com.querydsl.jpa.impl.JPAQueryFactory
 import org.springframework.stereotype.Component
+import team.mozu.dsm.adapter.`in`.organ.dto.response.OrganDetailResponse
+import team.mozu.dsm.adapter.`in`.organ.dto.response.QOrganDetailResponse
+import team.mozu.dsm.adapter.out.organ.entity.QOrganJpaEntity
 import team.mozu.dsm.adapter.out.organ.persistence.mapper.OrganMapper
 import team.mozu.dsm.adapter.out.organ.persistence.repository.OrganRepository
 import team.mozu.dsm.application.port.out.organ.QueryOrganPort
 import team.mozu.dsm.application.port.out.organ.CommandOrganPort
 import team.mozu.dsm.domain.organ.model.Organ
+import java.util.UUID
 
 @Component
 class OrganPersistenceAdapter(
     private val organRepository: OrganRepository,
-    private val organMapper: OrganMapper
+    private val organMapper: OrganMapper,
+    private val jpaQueryFactory: JPAQueryFactory
 ) : QueryOrganPort, CommandOrganPort {
+
+    private val organ = QOrganJpaEntity.organJpaEntity
 
     override fun findByOrganCode(organCode: String): Organ? {
         return organRepository.findByOrganCode(organCode)?.let { organMapper.toModel(it) }
@@ -21,5 +29,20 @@ class OrganPersistenceAdapter(
         val organ = organMapper.toEntity(organ)
         val savedOrgan = organRepository.save(organ)
         return organMapper.toModel(savedOrgan)
+    }
+
+    override fun findById(id: UUID): OrganDetailResponse? {
+        return jpaQueryFactory
+            .select(
+                QOrganDetailResponse(
+                    organ.id,
+                    organ.organCode,
+                    organ.organName,
+                    organ.password
+                )
+            )
+            .from(organ)
+            .where(organ.id.eq(id))
+            .fetchOne()
     }
 }

--- a/src/main/kotlin/team/mozu/dsm/application/port/in/organ/QueryOrganDetailUseCase.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/port/in/organ/QueryOrganDetailUseCase.kt
@@ -1,0 +1,9 @@
+package team.mozu.dsm.application.port.`in`.organ
+
+import team.mozu.dsm.adapter.`in`.organ.dto.response.OrganDetailResponse
+import java.util.*
+
+interface QueryOrganDetailUseCase {
+
+    fun queryOrganDetail(organId: UUID): OrganDetailResponse
+}

--- a/src/main/kotlin/team/mozu/dsm/application/port/in/organ/QueryOrganDetailUseCase.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/port/in/organ/QueryOrganDetailUseCase.kt
@@ -5,5 +5,5 @@ import java.util.*
 
 interface QueryOrganDetailUseCase {
 
-    fun queryOrganDetail(organId: UUID): OrganDetailResponse
+    fun queryOrganDetail(id: UUID): OrganDetailResponse
 }

--- a/src/main/kotlin/team/mozu/dsm/application/port/out/organ/QueryOrganPort.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/port/out/organ/QueryOrganPort.kt
@@ -1,8 +1,12 @@
 package team.mozu.dsm.application.port.out.organ
 
+import team.mozu.dsm.adapter.`in`.organ.dto.response.OrganDetailResponse
 import team.mozu.dsm.domain.organ.model.Organ
+import java.util.UUID
 
 interface QueryOrganPort {
 
     fun findByOrganCode(organCode: String): Organ?
+
+    fun findById(id: UUID): OrganDetailResponse?
 }

--- a/src/main/kotlin/team/mozu/dsm/application/service/organ/QueryOrganDetailService.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/service/organ/QueryOrganDetailService.kt
@@ -12,7 +12,7 @@ class QueryOrganDetailService(
     private val queryOrganPort: QueryOrganPort
 ) : QueryOrganDetailUseCase {
 
-    override fun queryOrganDetail(organId: UUID): OrganDetailResponse {
-        return queryOrganPort.findById(organId) ?: throw OrganNotFoundException
+    override fun queryOrganDetail(id: UUID): OrganDetailResponse {
+        return queryOrganPort.findById(id) ?: throw OrganNotFoundException
     }
 }

--- a/src/main/kotlin/team/mozu/dsm/application/service/organ/QueryOrganDetailService.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/service/organ/QueryOrganDetailService.kt
@@ -1,0 +1,18 @@
+package team.mozu.dsm.application.service.organ
+
+import org.springframework.stereotype.Service
+import team.mozu.dsm.adapter.`in`.organ.dto.response.OrganDetailResponse
+import team.mozu.dsm.application.exception.organ.OrganNotFoundException
+import team.mozu.dsm.application.port.`in`.organ.QueryOrganDetailUseCase
+import team.mozu.dsm.application.port.out.organ.QueryOrganPort
+import java.util.*
+
+@Service
+class QueryOrganDetailService(
+    private val queryOrganPort: QueryOrganPort
+) : QueryOrganDetailUseCase {
+
+    override fun queryOrganDetail(organId: UUID): OrganDetailResponse {
+        return queryOrganPort.findById(organId) ?: throw OrganNotFoundException
+    }
+}

--- a/src/main/kotlin/team/mozu/dsm/global/config/security/SecurityConfig.kt
+++ b/src/main/kotlin/team/mozu/dsm/global/config/security/SecurityConfig.kt
@@ -43,7 +43,7 @@ class SecurityConfig(
                 it.requestMatchers(HttpMethod.POST, "/organ/create").permitAll()
                 it.requestMatchers(HttpMethod.PATCH, "/organ/token/reissue").permitAll()
                 it.requestMatchers(HttpMethod.POST, "/organ/login").permitAll()
-                it.requestMatchers(HttpMethod.GET, "/organ/{organId}").permitAll()
+                it.requestMatchers(HttpMethod.GET, "/organ/{id}").permitAll()
 
                 //team
                 it.requestMatchers(HttpMethod.POST, "/team/participate").permitAll()

--- a/src/main/kotlin/team/mozu/dsm/global/config/security/SecurityConfig.kt
+++ b/src/main/kotlin/team/mozu/dsm/global/config/security/SecurityConfig.kt
@@ -43,6 +43,7 @@ class SecurityConfig(
                 it.requestMatchers(HttpMethod.POST, "/organ/create").permitAll()
                 it.requestMatchers(HttpMethod.PATCH, "/organ/token/reissue").permitAll()
                 it.requestMatchers(HttpMethod.POST, "/organ/login").permitAll()
+                it.requestMatchers(HttpMethod.GET, "/organ/{organId}").permitAll()
 
                 //team
                 it.requestMatchers(HttpMethod.POST, "/team/participate").permitAll()


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #68 

## 📝작업 내용

> [내부 ]기관 상세 조회 api를 개발하였습니다
> uuid를 통해 기관의 상세 정보를 조회하는 내부전용 api입니다
> QueryOrganDetailUseCase 구현
> QueryOrganPort에 findById 추가
> OrganPersistenceAdapter에 QueryDSL적용된 findById 추가
> QueryOrganDetailService 구현
> OrganWebAdapter에 단일 기관 조회 api 추가
> Get요청 /organ/{id} 경로 허용

### 
<img width="1710" height="1278" alt="image" src="https://github.com/user-attachments/assets/5d45b5e7-ecf8-4351-a7f2-63be197c51bc" />

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> 현재 세팅된 환경에 맞춰 UUID로 진행하였는데 기존 ERD와 api명세서에는 Long(INT)형으로 구현되어있어서 정수형으로 리펙토링을 해야 할지 고민됩니다
