### PR TITLE
Merge/mzbe 121 change isstarred status

### DIFF
--- a/src/main/kotlin/team/mozu/dsm/adapter/in/lesson/LessonWebAdapter.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/in/lesson/LessonWebAdapter.kt
@@ -6,6 +6,7 @@ import org.springframework.web.bind.annotation.*
 import team.mozu.dsm.adapter.`in`.lesson.dto.request.LessonRequest
 import team.mozu.dsm.adapter.`in`.lesson.dto.response.LessonResponse
 import team.mozu.dsm.adapter.`in`.lesson.dto.response.StartLessonResponse
+import team.mozu.dsm.application.port.`in`.lesson.ChangeStarredUseCase
 import team.mozu.dsm.application.port.`in`.lesson.CreateLessonUseCase
 import team.mozu.dsm.application.port.`in`.lesson.StartLessonUseCase
 import java.util.UUID
@@ -14,7 +15,8 @@ import java.util.UUID
 @RequestMapping("/lesson")
 class LessonWebAdapter(
     private val createLessonUseCase: CreateLessonUseCase,
-    private val startLessonUseCase: StartLessonUseCase
+    private val startLessonUseCase: StartLessonUseCase,
+    private val changeStarredUseCase: ChangeStarredUseCase
 ) {
 
     @PostMapping
@@ -32,5 +34,13 @@ class LessonWebAdapter(
         @PathVariable("lesson-id") lessonId: UUID
     ): StartLessonResponse {
         return startLessonUseCase.start(lessonId)
+    }
+
+    @PatchMapping("/star/{lesson-id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun star(
+        @PathVariable("lesson-id") lessonId: UUID
+    ) {
+        changeStarredUseCase.change(lessonId)
     }
 }

--- a/src/main/kotlin/team/mozu/dsm/adapter/out/lesson/persistence/LessonPersistenceAdapter.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/out/lesson/persistence/LessonPersistenceAdapter.kt
@@ -55,4 +55,12 @@ class LessonPersistenceAdapter(
             .where(lessonJpaEntity.id.eq(id))
             .execute()
     }
+
+    override fun updateIsStarred(id: UUID) {
+        jpaQueryFactory
+            .update(lessonJpaEntity)
+            .set(lessonJpaEntity.isStarred, lessonJpaEntity.isStarred.not())
+            .where(lessonJpaEntity.id.eq(id))
+            .execute()
+    }
 }

--- a/src/main/kotlin/team/mozu/dsm/application/port/in/lesson/ChangeStarredUseCase.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/port/in/lesson/ChangeStarredUseCase.kt
@@ -1,0 +1,8 @@
+package team.mozu.dsm.application.port.`in`.lesson
+
+import java.util.UUID
+
+interface ChangeStarredUseCase {
+
+    fun change(id: UUID)
+}

--- a/src/main/kotlin/team/mozu/dsm/application/port/out/lesson/CommandLessonPort.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/port/out/lesson/CommandLessonPort.kt
@@ -8,4 +8,6 @@ interface CommandLessonPort {
     fun save(lesson: Lesson): Lesson
 
     fun updateLessonNumAndIsInProgress(id: UUID, lessonNum: String)
+
+    fun updateIsStarred(id: UUID)
 }

--- a/src/main/kotlin/team/mozu/dsm/application/service/lesson/ChangeStarredService.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/service/lesson/ChangeStarredService.kt
@@ -1,0 +1,24 @@
+package team.mozu.dsm.application.service.lesson
+
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import team.mozu.dsm.application.exception.lesson.LessonNotFoundException
+import team.mozu.dsm.application.port.`in`.lesson.ChangeStarredUseCase
+import team.mozu.dsm.application.port.out.lesson.CommandLessonPort
+import team.mozu.dsm.application.port.out.lesson.QueryLessonPort
+import java.util.UUID
+
+@Service
+class ChangeStarredService(
+    private val queryLessonPort: QueryLessonPort,
+    private val commandLessonPort: CommandLessonPort
+): ChangeStarredUseCase {
+
+    @Transactional
+    override fun change(id: UUID) {
+        val lesson = queryLessonPort.findById(id)
+            ?: throw LessonNotFoundException
+
+        commandLessonPort.updateIsStarred(lesson.id!!)
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

- #77 

## 📝작업 내용

> 수업 즐겨찾기 변경 API 개발

### 스크린샷 (선택)
<img width="1586" height="766" alt="image" src="https://github.com/user-attachments/assets/daa57d0b-fe45-49c8-8121-1e596be41f2f" />


## 💬리뷰 요구사항(선택) 꼭 읽어보시용

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- 현재 브랜치에서는 수업 즐겨찾기 시, 로그인한 기관이 생성한 수업인지 확인하는 조건문을 아직 추가하지 못했습니다. 해당 브랜치를 기반으로 rebase하여 개발된 API가 많아, 모든 브랜치가 develop에 머지된 이후에 적용할 예정입니다.
- 추후 올라갈 PR에서도 lesson 객체 조회를 위한 findById 호출이 중복 작성되어 LessonFacade로 분리하였으나, 이번 코드에는 아직 반영되지 않았습니다. 코드 리뷰 하실 때 참고 부탁드립니다!
- API 명세서에는 HTTP Method가 POST로 되어 있으나, isStarred의 boolean값만 변경하므로 PATCH로 개발했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 새 기능
  - 강의를 즐겨찾기(스타)로 표시하거나 해제할 수 있는 기능을 추가했습니다. 새 PATCH 엔드포인트 /lesson/star/{lesson-id}로 즐겨찾기 상태를 토글할 수 있습니다.
  - 요청이 성공하면 본문 없는 204(No Content)를 반환합니다. 동일 엔드포인트를 반복 호출하면 상태가 전환됩니다.
  - 기존 강의 생성 및 시작 기능은 변경 없이 그대로 동작합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->