### PR TITLE
Merge/mzbe 122 delete lesson

### DIFF
--- a/src/main/kotlin/team/mozu/dsm/adapter/in/lesson/LessonWebAdapter.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/in/lesson/LessonWebAdapter.kt
@@ -2,12 +2,20 @@ package team.mozu.dsm.adapter.`in`.lesson
 
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
-import org.springframework.web.bind.annotation.*
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.DeleteMapping
 import team.mozu.dsm.adapter.`in`.lesson.dto.request.LessonRequest
 import team.mozu.dsm.adapter.`in`.lesson.dto.response.LessonResponse
 import team.mozu.dsm.adapter.`in`.lesson.dto.response.StartLessonResponse
 import team.mozu.dsm.application.port.`in`.lesson.ChangeStarredUseCase
 import team.mozu.dsm.application.port.`in`.lesson.CreateLessonUseCase
+import team.mozu.dsm.application.port.`in`.lesson.DeleteLessonUseCase
 import team.mozu.dsm.application.port.`in`.lesson.StartLessonUseCase
 import java.util.UUID
 
@@ -16,7 +24,8 @@ import java.util.UUID
 class LessonWebAdapter(
     private val createLessonUseCase: CreateLessonUseCase,
     private val startLessonUseCase: StartLessonUseCase,
-    private val changeStarredUseCase: ChangeStarredUseCase
+    private val changeStarredUseCase: ChangeStarredUseCase,
+    private val deleteLessonUseCase: DeleteLessonUseCase
 ) {
 
     @PostMapping
@@ -42,5 +51,13 @@ class LessonWebAdapter(
         @PathVariable("lesson-id") lessonId: UUID
     ) {
         changeStarredUseCase.change(lessonId)
+    }
+
+    @DeleteMapping("/{lesson-id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun delete(
+        @PathVariable("lesson-id") lessonId: UUID
+    ) {
+        deleteLessonUseCase.delete(lessonId)
     }
 }

--- a/src/main/kotlin/team/mozu/dsm/adapter/out/lesson/persistence/LessonPersistenceAdapter.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/out/lesson/persistence/LessonPersistenceAdapter.kt
@@ -63,4 +63,12 @@ class LessonPersistenceAdapter(
             .where(lessonJpaEntity.id.eq(id))
             .execute()
     }
+
+    override fun delete(id: UUID) {
+        jpaQueryFactory
+            .update(lessonJpaEntity)
+            .set(lessonJpaEntity.isDeleted, true)
+            .where(lessonJpaEntity.id.eq(id))
+            .execute()
+    }
 }

--- a/src/main/kotlin/team/mozu/dsm/application/port/in/lesson/DeleteLessonUseCase.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/port/in/lesson/DeleteLessonUseCase.kt
@@ -1,0 +1,8 @@
+package team.mozu.dsm.application.port.`in`.lesson
+
+import java.util.UUID
+
+interface DeleteLessonUseCase {
+
+    fun delete(id: UUID)
+}

--- a/src/main/kotlin/team/mozu/dsm/application/port/in/lesson/StartLessonUseCase.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/port/in/lesson/StartLessonUseCase.kt
@@ -5,5 +5,5 @@ import java.util.UUID
 
 interface StartLessonUseCase {
 
-    fun start(id: UUID) : StartLessonResponse
+    fun start(id: UUID): StartLessonResponse
 }

--- a/src/main/kotlin/team/mozu/dsm/application/port/out/lesson/CommandLessonPort.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/port/out/lesson/CommandLessonPort.kt
@@ -10,4 +10,6 @@ interface CommandLessonPort {
     fun updateLessonNumAndIsInProgress(id: UUID, lessonNum: String)
 
     fun updateIsStarred(id: UUID)
+
+    fun delete(id: UUID)
 }

--- a/src/main/kotlin/team/mozu/dsm/application/service/lesson/ChangeStarredService.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/service/lesson/ChangeStarredService.kt
@@ -12,7 +12,7 @@ import java.util.UUID
 class ChangeStarredService(
     private val queryLessonPort: QueryLessonPort,
     private val commandLessonPort: CommandLessonPort
-): ChangeStarredUseCase {
+) : ChangeStarredUseCase {
 
     @Transactional
     override fun change(id: UUID) {

--- a/src/main/kotlin/team/mozu/dsm/application/service/lesson/DeleteLessonService.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/service/lesson/DeleteLessonService.kt
@@ -1,0 +1,24 @@
+package team.mozu.dsm.application.service.lesson
+
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import team.mozu.dsm.application.exception.lesson.LessonNotFoundException
+import team.mozu.dsm.application.port.`in`.lesson.DeleteLessonUseCase
+import team.mozu.dsm.application.port.out.lesson.CommandLessonPort
+import team.mozu.dsm.application.port.out.lesson.QueryLessonPort
+import java.util.UUID
+
+@Service
+class DeleteLessonService(
+    private val queryLessonPort: QueryLessonPort,
+    private val commandLessonPort: CommandLessonPort
+) : DeleteLessonUseCase {
+
+    @Transactional
+    override fun delete(id: UUID) {
+        val lesson = queryLessonPort.findById(id)
+            ?: throw LessonNotFoundException
+
+        commandLessonPort.delete(lesson.id!!)
+    }
+}

--- a/src/main/kotlin/team/mozu/dsm/application/service/lesson/StartLessonService.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/service/lesson/StartLessonService.kt
@@ -15,9 +15,9 @@ import java.util.UUID
 class StartLessonService(
     private val queryLessonPort: QueryLessonPort,
     private val commandLessonPort: CommandLessonPort
-): StartLessonUseCase {
+) : StartLessonUseCase {
 
-    companion object{
+    companion object {
         val random: SecureRandom = SecureRandom()
     }
 

--- a/src/main/kotlin/team/mozu/dsm/global/security/SecurityAdapter.kt
+++ b/src/main/kotlin/team/mozu/dsm/global/security/SecurityAdapter.kt
@@ -16,7 +16,7 @@ class SecurityAdapter(
 
     override fun getCurrentOrgan(): Organ {
         val organCode = SecurityContextHolder.getContext().authentication.name
-        val entity =  organRepository.findByOrganCode(organCode)
+        val entity = organRepository.findByOrganCode(organCode)
             ?: throw OrganNotFoundException
 
         return organMapper.toModel(entity)


### PR DESCRIPTION
## #️⃣연관된 이슈

- #79 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
<img width="1604" height="848" alt="image" src="https://github.com/user-attachments/assets/c32f2125-b9b8-4cd1-aed0-09eb8a60eced" />

실제로는 DB에서 지우지 않고, isDeleted만 true로 변경
<img width="374" height="180" alt="image" src="https://github.com/user-attachments/assets/1fe07960-0ca7-47b7-8d12-b3bdc451f815" />


### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- 현재 브랜치에서는 수업 삭제 시, 로그인한 기관이 생성한 수업인지 확인하는 조건문을 아직 추가하지 못했습니다. 해당 브랜치를 기반으로 rebase하여 개발된 API가 많아, 모든 브랜치가 develop에 머지된 이후에 적용할 예정입니다.
- 추후 올라갈 PR에서도 lesson 객체 조회를 위한 findById 호출이 중복 작성되어 LessonFacade로 분리하였으나, 이번 코드에는 아직 반영되지 않았습니다. 코드 리뷰 하실 때 참고 부탁드립니다!
- 실제로는 DB에서 삭제하지 않고, isDeleted만 true로 변경하여서 PATCH도 고려하였으나 요청 자체는 리소스를 삭제하기 위한 의도이므로 PATCH보다는 DELETE 메서드가 더 적절하다고 판단하여 DELETE로 개발하였습니다.

