### PR TITLE
Merge/mzbe 133 get lesson detail

### DIFF
--- a/src/main/kotlin/team/mozu/dsm/adapter/in/lesson/LessonWebAdapter.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/in/lesson/LessonWebAdapter.kt
@@ -2,12 +2,13 @@ package team.mozu.dsm.adapter.`in`.lesson
 
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
-import org.springframework.web.bind.annotation.RestController
-import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.DeleteMapping
 import team.mozu.dsm.adapter.`in`.lesson.dto.request.LessonRequest
@@ -19,6 +20,8 @@ import team.mozu.dsm.application.port.`in`.lesson.DeleteLessonUseCase
 import team.mozu.dsm.application.port.`in`.lesson.StartLessonUseCase
 import team.mozu.dsm.application.port.`in`.lesson.EndLessonUseCase
 import team.mozu.dsm.application.port.`in`.lesson.UpdateLessonUseCase
+import team.mozu.dsm.application.port.`in`.lesson.GetLessonDetailUseCase
+
 import java.util.UUID
 
 @RestController
@@ -29,7 +32,8 @@ class LessonWebAdapter(
     private val changeStarredUseCase: ChangeStarredUseCase,
     private val deleteLessonUseCase: DeleteLessonUseCase,
     private val endLessonUseCase: EndLessonUseCase,
-    private val updateLessonUseCase: UpdateLessonUseCase
+    private val updateLessonUseCase: UpdateLessonUseCase,
+    private val getLessonDetailUseCase: GetLessonDetailUseCase,
 ) {
 
     @PostMapping
@@ -81,5 +85,13 @@ class LessonWebAdapter(
         request: LessonRequest
     ): LessonResponse {
         return updateLessonUseCase.update(lessonId, request)
+    }
+
+    @GetMapping("/{lesson-id}")
+    @ResponseStatus(HttpStatus.OK)
+    fun getDetail(
+        @PathVariable("lesson-id") lessonId: UUID
+    ): LessonResponse {
+        return getLessonDetailUseCase.get(lessonId)
     }
 }

--- a/src/main/kotlin/team/mozu/dsm/adapter/out/lesson/persistence/LessonArticlePersistenceAdapter.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/out/lesson/persistence/LessonArticlePersistenceAdapter.kt
@@ -10,6 +10,7 @@ import team.mozu.dsm.adapter.out.lesson.persistence.repository.LessonRepository
 import team.mozu.dsm.application.exception.article.ArticleNotFoundException
 import team.mozu.dsm.application.exception.lesson.LessonNotFoundException
 import team.mozu.dsm.application.port.out.lesson.CommandLessonArticlePort
+import team.mozu.dsm.application.port.out.lesson.QueryLessonArticlePort
 import team.mozu.dsm.domain.lesson.model.LessonArticle
 import java.util.UUID
 
@@ -20,9 +21,13 @@ class LessonArticlePersistenceAdapter(
     private val lessonArticleMapper: LessonArticleMapper,
     private val lessonArticleRepository: LessonArticleRepository,
     private val jpaQueryFactory: JPAQueryFactory
-) : CommandLessonArticlePort {
+) : QueryLessonArticlePort, CommandLessonArticlePort {
 
     //--Query--//
+    override fun findAllByLessonId(lessonId: UUID): List<LessonArticle> {
+        return lessonArticleRepository.findAllByLessonId(lessonId)
+            .map { lessonArticleMapper.toModel(it) }
+    }
 
     //--Command--//
     override fun saveAll(id: UUID, lessonArticles: List<LessonArticle>): List<LessonArticle> {

--- a/src/main/kotlin/team/mozu/dsm/adapter/out/lesson/persistence/LessonItemPersistenceAdapter.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/out/lesson/persistence/LessonItemPersistenceAdapter.kt
@@ -45,6 +45,11 @@ class LessonItemPersistenceAdapter(
         return entities.map { lessonItemMapper.toModel(it) }
     }
 
+    override fun findAllByLessonId(lessonId: UUID): List<LessonItem> {
+        return lessonItemRepository.findAllByLessonId(lessonId)
+            .map { lessonItemMapper.toModel(it) }
+    }
+
     //--Command--//
     override fun saveAll(id: UUID, lessonItems: List<LessonItem>): List<LessonItem> {
         val lessonEntity = lessonRepository.findById(id)

--- a/src/main/kotlin/team/mozu/dsm/adapter/out/lesson/persistence/repository/LessonArticleRepository.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/out/lesson/persistence/repository/LessonArticleRepository.kt
@@ -3,5 +3,9 @@ package team.mozu.dsm.adapter.out.lesson.persistence.repository
 import org.springframework.data.jpa.repository.JpaRepository
 import team.mozu.dsm.adapter.out.lesson.entity.LessonArticleJpaEntity
 import team.mozu.dsm.adapter.out.lesson.entity.id.LessonArticleId
+import java.util.*
 
-interface LessonArticleRepository : JpaRepository<LessonArticleJpaEntity, LessonArticleId>
+interface LessonArticleRepository : JpaRepository<LessonArticleJpaEntity, LessonArticleId> {
+
+    fun findAllByLessonId(lessonId: UUID): List<LessonArticleJpaEntity>
+}

--- a/src/main/kotlin/team/mozu/dsm/adapter/out/lesson/persistence/repository/LessonItemRepository.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/out/lesson/persistence/repository/LessonItemRepository.kt
@@ -3,5 +3,9 @@ package team.mozu.dsm.adapter.out.lesson.persistence.repository
 import org.springframework.data.jpa.repository.JpaRepository
 import team.mozu.dsm.adapter.out.lesson.entity.LessonItemJpaEntity
 import team.mozu.dsm.adapter.out.lesson.entity.id.LessonItemId
+import java.util.*
 
-interface LessonItemRepository : JpaRepository<LessonItemJpaEntity, LessonItemId>
+interface LessonItemRepository : JpaRepository<LessonItemJpaEntity, LessonItemId> {
+
+    fun findAllByLessonId(lessonId: UUID): List<LessonItemJpaEntity>
+}

--- a/src/main/kotlin/team/mozu/dsm/application/port/in/lesson/GetLessonDetailUseCase.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/port/in/lesson/GetLessonDetailUseCase.kt
@@ -1,0 +1,9 @@
+package team.mozu.dsm.application.port.`in`.lesson
+
+import team.mozu.dsm.adapter.`in`.lesson.dto.response.LessonResponse
+import java.util.*
+
+interface GetLessonDetailUseCase {
+
+    fun get(id: UUID): LessonResponse
+}

--- a/src/main/kotlin/team/mozu/dsm/application/port/out/lesson/QueryLessonArticlePort.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/port/out/lesson/QueryLessonArticlePort.kt
@@ -1,0 +1,9 @@
+package team.mozu.dsm.application.port.out.lesson
+
+import team.mozu.dsm.domain.lesson.model.LessonArticle
+import java.util.*
+
+interface QueryLessonArticlePort {
+
+    fun findAllByLessonId(lessonId: UUID): List<LessonArticle>
+}

--- a/src/main/kotlin/team/mozu/dsm/application/port/out/lesson/QueryLessonItemPort.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/port/out/lesson/QueryLessonItemPort.kt
@@ -8,4 +8,6 @@ interface QueryLessonItemPort {
     fun findItemIdsByLessonId(lessonId: UUID): List<UUID>
 
     fun findAllByLessonIdAndItemIds(lessonId: UUID, itemIds: List<UUID>): List<LessonItem>
+
+    fun findAllByLessonId(lessonId: UUID): List<LessonItem>
 }

--- a/src/main/kotlin/team/mozu/dsm/application/service/lesson/GetLessonDetailService.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/service/lesson/GetLessonDetailService.kt
@@ -1,12 +1,13 @@
 package team.mozu.dsm.application.service.lesson
 
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 import team.mozu.dsm.adapter.`in`.lesson.dto.response.LessonResponse
 import team.mozu.dsm.application.port.`in`.lesson.GetLessonDetailUseCase
 import team.mozu.dsm.application.port.out.lesson.QueryLessonArticlePort
 import team.mozu.dsm.application.port.out.lesson.QueryLessonItemPort
 import team.mozu.dsm.application.service.lesson.facade.LessonFacade
-import java.util.*
+import java.util.UUID
 
 @Service
 class GetLessonDetailService(
@@ -15,6 +16,7 @@ class GetLessonDetailService(
     private val lessonArticlePort: QueryLessonArticlePort
 ): GetLessonDetailUseCase {
 
+    @Transactional(readOnly = true)
     override fun get(id: UUID): LessonResponse {
         val lesson = lessonFacade.findByLessonId(id)
 

--- a/src/main/kotlin/team/mozu/dsm/application/service/lesson/GetLessonDetailService.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/service/lesson/GetLessonDetailService.kt
@@ -1,0 +1,42 @@
+package team.mozu.dsm.application.service.lesson
+
+import org.springframework.stereotype.Service
+import team.mozu.dsm.adapter.`in`.lesson.dto.response.LessonResponse
+import team.mozu.dsm.application.port.`in`.lesson.GetLessonDetailUseCase
+import team.mozu.dsm.application.port.out.lesson.QueryLessonArticlePort
+import team.mozu.dsm.application.port.out.lesson.QueryLessonItemPort
+import team.mozu.dsm.application.service.lesson.facade.LessonFacade
+import java.util.*
+
+@Service
+class GetLessonDetailService(
+    private val lessonFacade: LessonFacade,
+    private val lessonItemPort: QueryLessonItemPort,
+    private val lessonArticlePort: QueryLessonArticlePort
+): GetLessonDetailUseCase {
+
+    override fun get(id: UUID): LessonResponse {
+        val lesson = lessonFacade.findByLessonId(id)
+
+        val lessonItems = lessonItemPort.findAllByLessonId(lesson.id!!)
+        val lessonArticles = lessonArticlePort.findAllByLessonId(lesson.id)
+
+        val lessonItemResponses = lessonFacade.toLessonItemResponses(lessonItems)
+        val lessonArticleResponses = lessonFacade.toLessonArticleResponses(lessonArticles)
+
+        return LessonResponse(
+            id = lesson.id,
+            name = lesson.lessonName,
+            maxInvRound = lesson.maxInvRound,
+            curInvRound = lesson.curInvRound,
+            baseMoney = lesson.baseMoney,
+            lessonNum = lesson.lessonNum,
+            isInProgress = lesson.isInProgress,
+            isStarred = lesson.isStarred,
+            isDeleted = lesson.isDeleted,
+            createdAt = lesson.createdAt!!,
+            lessonItems = lessonItemResponses,
+            lessonArticles = lessonArticleResponses
+        )
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

- #88 

## 📝작업 내용

- 수업 상세조회 API 개발

### 스크린샷 (선택)
<img width="1578" height="1288" alt="image" src="https://github.com/user-attachments/assets/0628f722-5ca2-4895-9c81-3da49fd64927" />


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 레슨 상세 조회 API가 추가되었습니다. 지정한 ID로 레슨을 조회할 수 있습니다. (GET /lesson/{lesson-id})
  - 응답에는 레슨 기본 정보와 연결된 레슨 아이템 및 레슨 아티클 전체 목록이 포함됩니다.
  - 성공 시 표준 HTTP 200 OK로 상세 정보를 반환하며 기존 목록/기본 조회 흐름은 변경되지 않습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->