### PR TITLE
Merge/mzbe 143 get order item

### DIFF
--- a/src/main/kotlin/team/mozu/dsm/adapter/in/team/TeamWebAdapter.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/in/team/TeamWebAdapter.kt
@@ -11,13 +11,15 @@ import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 import team.mozu.dsm.adapter.`in`.team.dto.request.CompleteInvestmentRequest
 import team.mozu.dsm.adapter.`in`.team.dto.request.TeamParticipationRequest
+import team.mozu.dsm.adapter.`in`.team.dto.response.OrderItemResponse
 import team.mozu.dsm.adapter.`in`.team.dto.response.StockResponse
 import team.mozu.dsm.adapter.`in`.team.dto.response.TeamDetailResponse
 import team.mozu.dsm.adapter.`in`.team.dto.response.TeamTokenResponse
+import team.mozu.dsm.application.port.`in`.team.TeamParticipationUseCase
 import team.mozu.dsm.application.port.`in`.team.CompleteTeamInvestmentUseCase
 import team.mozu.dsm.application.port.`in`.team.GetStocksUseCase
 import team.mozu.dsm.application.port.`in`.team.GetTeamDetailUseCase
-import team.mozu.dsm.application.port.`in`.team.TeamParticipationUseCase
+import team.mozu.dsm.application.port.`in`.team.GetOrderItemUseCase
 import team.mozu.dsm.global.security.auth.StudentPrincipal
 
 @RestController
@@ -26,7 +28,8 @@ class TeamWebAdapter(
     private val teamParticipationUseCase: TeamParticipationUseCase,
     private val teamInvestmentUseCase: CompleteTeamInvestmentUseCase,
     private val getStocksUseCase: GetStocksUseCase,
-    private val getTeamDetailUseCase: GetTeamDetailUseCase
+    private val getTeamDetailUseCase: GetTeamDetailUseCase,
+    private val getOrderItemUseCase: GetOrderItemUseCase
 ) {
     @PostMapping("/participate")
     @ResponseStatus(HttpStatus.CREATED)
@@ -61,5 +64,13 @@ class TeamWebAdapter(
         @AuthenticationPrincipal principal: StudentPrincipal
     ): TeamDetailResponse {
         return getTeamDetailUseCase.getTeamDetail(principal.lessonNum, principal.teamId)
+    }
+
+    @GetMapping("/orders")
+    @ResponseStatus(HttpStatus.OK)
+    fun getOrderItems(
+        @AuthenticationPrincipal principal: StudentPrincipal
+    ): List<OrderItemResponse> {
+        return getOrderItemUseCase.getOrderItems(principal.teamId)
     }
 }

--- a/src/main/kotlin/team/mozu/dsm/adapter/in/team/dto/request/CompleteInvestmentRequest.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/in/team/dto/request/CompleteInvestmentRequest.kt
@@ -20,7 +20,7 @@ data class CompleteInvestmentRequest(
     val orderCount: Int,
 
     @field:Min(value = 1, message = "총 금액은 1원 이상이어야 합니다")
-    val totalAmount: Int,
+    val totalMoney: Int,
 
     @field:NotNull(message = "주문 타입은 필수입니다")
     val orderType: OrderType

--- a/src/main/kotlin/team/mozu/dsm/adapter/in/team/dto/response/OrderItemResponse.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/in/team/dto/response/OrderItemResponse.kt
@@ -1,0 +1,15 @@
+package team.mozu.dsm.adapter.`in`.team.dto.response
+
+import team.mozu.dsm.domain.team.type.OrderType
+import java.util.UUID
+
+data class OrderItemResponse(
+    val id: UUID,
+    val itemId: UUID,
+    val itemName: String,
+    val itemPrice: Int,
+    val orderCount: Int,
+    val totalMoney: Int,
+    val orderType: OrderType,
+    val invCount: Int
+)

--- a/src/main/kotlin/team/mozu/dsm/adapter/out/team/entity/OrderItemJpaEntity.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/out/team/entity/OrderItemJpaEntity.kt
@@ -30,7 +30,7 @@ class OrderItemJpaEntity(
     var itemPrice: Int,
 
     @Column(nullable = false)
-    var totalAmount: Int,
+    var totalMoney: Int,
 
     @Column(nullable = false)
     var invCount: Int,

--- a/src/main/kotlin/team/mozu/dsm/adapter/out/team/persistence/OrderItemPersistenceAdapter.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/out/team/persistence/OrderItemPersistenceAdapter.kt
@@ -19,7 +19,7 @@ class OrderItemPersistenceAdapter(
     private val itemRepository: ItemRepository,
     private val teamRepository: TeamRepository,
     private val orderItemMapper: OrderItemMapper
-) : QueryOrderItemPort, CommandOrderItemPort {
+) : CommandOrderItemPort, QueryOrderItemPort {
 
     //--Query--//
     override fun findAllByTeamId(teamId: UUID): List<OrderItem> {

--- a/src/main/kotlin/team/mozu/dsm/adapter/out/team/persistence/OrderItemPersistenceAdapter.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/out/team/persistence/OrderItemPersistenceAdapter.kt
@@ -9,7 +9,9 @@ import team.mozu.dsm.adapter.out.team.persistence.repository.TeamRepository
 import team.mozu.dsm.application.exception.item.ItemNotFoundException
 import team.mozu.dsm.application.exception.team.TeamNotFoundException
 import team.mozu.dsm.application.port.out.team.CommandOrderItemPort
+import team.mozu.dsm.application.port.out.team.QueryOrderItemPort
 import team.mozu.dsm.domain.team.model.OrderItem
+import java.util.UUID
 
 @Component
 class OrderItemPersistenceAdapter(
@@ -17,8 +19,16 @@ class OrderItemPersistenceAdapter(
     private val itemRepository: ItemRepository,
     private val teamRepository: TeamRepository,
     private val orderItemMapper: OrderItemMapper
-) : CommandOrderItemPort {
+) : QueryOrderItemPort, CommandOrderItemPort {
 
+    //--Query--//
+    override fun findAllByTeamId(teamId: UUID): List<OrderItem> {
+        val entities = orderItemRepository.findAllByTeamId(teamId)
+
+        return entities.map { orderItemMapper.toModel(it) }
+    }
+
+    //--Command--//
     override fun saveAll(orderItems: List<OrderItem>) {
         if (orderItems.isEmpty()) return
 

--- a/src/main/kotlin/team/mozu/dsm/adapter/out/team/persistence/StockPersistenceAdapter.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/out/team/persistence/StockPersistenceAdapter.kt
@@ -19,7 +19,7 @@ class StockPersistenceAdapter(
     private val teamRepository: TeamRepository,
     private val itemRepository: ItemRepository,
     private val stockMapper: StockMapper
-) : QueryStockPort, CommandStockPort {
+) : CommandStockPort, QueryStockPort {
 
     //--Query--//
     override fun findByTeamIdAndItemId(teamId: UUID, itemId: UUID): Stock? {

--- a/src/main/kotlin/team/mozu/dsm/adapter/out/team/persistence/mapper/OrderItemMapper.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/out/team/persistence/mapper/OrderItemMapper.kt
@@ -22,7 +22,7 @@ abstract class OrderItemMapper {
             orderType = model.orderType,
             orderCount = model.orderCount,
             itemPrice = model.itemPrice,
-            totalAmount = model.totalAmount,
+            totalMoney = model.totalMoney,
             invCount = model.invCount
         )
     }

--- a/src/main/kotlin/team/mozu/dsm/adapter/out/team/persistence/repository/OrderItemRepository.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/out/team/persistence/repository/OrderItemRepository.kt
@@ -4,4 +4,7 @@ import org.springframework.data.jpa.repository.JpaRepository
 import team.mozu.dsm.adapter.out.team.entity.OrderItemJpaEntity
 import java.util.UUID
 
-interface OrderItemRepository : JpaRepository<OrderItemJpaEntity, UUID>
+interface OrderItemRepository : JpaRepository<OrderItemJpaEntity, UUID> {
+
+    fun findAllByTeamId(teamId: UUID): List<OrderItemJpaEntity>
+}

--- a/src/main/kotlin/team/mozu/dsm/adapter/out/team/persistence/repository/OrderItemRepository.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/out/team/persistence/repository/OrderItemRepository.kt
@@ -1,10 +1,12 @@
 package team.mozu.dsm.adapter.out.team.persistence.repository
 
+import org.springframework.data.jpa.repository.EntityGraph
 import org.springframework.data.jpa.repository.JpaRepository
 import team.mozu.dsm.adapter.out.team.entity.OrderItemJpaEntity
 import java.util.UUID
 
 interface OrderItemRepository : JpaRepository<OrderItemJpaEntity, UUID> {
 
+    @EntityGraph(attributePaths = ["item", "team"])
     fun findAllByTeamId(teamId: UUID): List<OrderItemJpaEntity>
 }

--- a/src/main/kotlin/team/mozu/dsm/application/port/in/team/GetOrderItemUseCase.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/port/in/team/GetOrderItemUseCase.kt
@@ -1,0 +1,9 @@
+package team.mozu.dsm.application.port.`in`.team
+
+import team.mozu.dsm.adapter.`in`.team.dto.response.OrderItemResponse
+import java.util.UUID
+
+interface GetOrderItemUseCase {
+
+    fun getOrderItems(teamId: UUID): List<OrderItemResponse>
+}

--- a/src/main/kotlin/team/mozu/dsm/application/port/out/team/QueryOrderItemPort.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/port/out/team/QueryOrderItemPort.kt
@@ -1,0 +1,9 @@
+package team.mozu.dsm.application.port.out.team
+
+import team.mozu.dsm.domain.team.model.OrderItem
+import java.util.UUID
+
+interface QueryOrderItemPort {
+
+    fun findAllByTeamId(teamId: UUID): List<OrderItem>
+}

--- a/src/main/kotlin/team/mozu/dsm/application/service/lesson/GetLessonDetailService.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/service/lesson/GetLessonDetailService.kt
@@ -14,7 +14,7 @@ class GetLessonDetailService(
     private val lessonFacade: LessonFacade,
     private val lessonItemPort: QueryLessonItemPort,
     private val lessonArticlePort: QueryLessonArticlePort
-): GetLessonDetailUseCase {
+) : GetLessonDetailUseCase {
 
     @Transactional(readOnly = true)
     override fun get(id: UUID): LessonResponse {

--- a/src/main/kotlin/team/mozu/dsm/application/service/team/CompleteTeamInvestmentService.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/service/team/CompleteTeamInvestmentService.kt
@@ -73,7 +73,7 @@ class CompleteTeamInvestmentService(
                 orderType = req.orderType,
                 orderCount = req.orderCount,
                 itemPrice = req.itemPrice,
-                totalAmount = req.totalAmount,
+                totalMoney = req.totalMoney,
                 invCount = lesson.curInvRound,
                 createdAt = LocalDateTime.now(),
                 updatedAt = null

--- a/src/main/kotlin/team/mozu/dsm/application/service/team/GetOrderItemService.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/service/team/GetOrderItemService.kt
@@ -1,6 +1,7 @@
 package team.mozu.dsm.application.service.team
 
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 import team.mozu.dsm.adapter.`in`.team.dto.response.OrderItemResponse
 import team.mozu.dsm.application.port.`in`.team.GetOrderItemUseCase
 import team.mozu.dsm.application.port.out.team.QueryOrderItemPort
@@ -11,6 +12,7 @@ class GetOrderItemService(
     private val queryOrderItemPort: QueryOrderItemPort
 ) : GetOrderItemUseCase {
 
+    @Transactional(readOnly = true)
     override fun getOrderItems(teamId: UUID): List<OrderItemResponse> {
         val orderItems = queryOrderItemPort.findAllByTeamId(teamId)
 

--- a/src/main/kotlin/team/mozu/dsm/application/service/team/GetOrderItemService.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/service/team/GetOrderItemService.kt
@@ -1,0 +1,30 @@
+package team.mozu.dsm.application.service.team
+
+import org.springframework.stereotype.Service
+import team.mozu.dsm.adapter.`in`.team.dto.response.OrderItemResponse
+import team.mozu.dsm.application.port.`in`.team.GetOrderItemUseCase
+import team.mozu.dsm.application.port.out.team.QueryOrderItemPort
+import java.util.UUID
+
+@Service
+class GetOrderItemService(
+    private val queryOrderItemPort: QueryOrderItemPort
+) : GetOrderItemUseCase {
+
+    override fun getOrderItems(teamId: UUID): List<OrderItemResponse> {
+        val orderItems = queryOrderItemPort.findAllByTeamId(teamId)
+
+        return orderItems.map { orderItem ->
+            OrderItemResponse(
+                id = orderItem.id!!,
+                itemId = orderItem.itemId,
+                itemName = orderItem.itemName,
+                itemPrice = orderItem.itemPrice,
+                orderCount = orderItem.orderCount,
+                totalMoney = orderItem.totalMoney,
+                orderType = orderItem.orderType,
+                invCount = orderItem.invCount
+            )
+        }
+    }
+}

--- a/src/main/kotlin/team/mozu/dsm/domain/team/model/OrderItem.kt
+++ b/src/main/kotlin/team/mozu/dsm/domain/team/model/OrderItem.kt
@@ -14,7 +14,7 @@ data class OrderItem(
     val orderType: OrderType,
     val orderCount: Int,
     val itemPrice: Int,
-    val totalAmount: Int,
+    val totalMoney: Int,
     val invCount: Int,
     val createdAt: LocalDateTime,
     val updatedAt: LocalDateTime?

--- a/src/main/kotlin/team/mozu/dsm/global/config/security/SecurityConfig.kt
+++ b/src/main/kotlin/team/mozu/dsm/global/config/security/SecurityConfig.kt
@@ -51,6 +51,7 @@ class SecurityConfig(
                 it.requestMatchers(HttpMethod.POST, "/team/end").hasAnyRole("STUDENT")
                 it.requestMatchers(HttpMethod.GET, "/team/stocks").hasAnyRole("STUDENT")
                 it.requestMatchers(HttpMethod.GET, "/team/detail").hasAnyRole("STUDENT")
+                it.requestMatchers(HttpMethod.GET, "/team/orders").hasAnyRole("STUDENT")
                     .anyRequest().authenticated()
             }
             .with(FilterConfig(jwtTokenProvider, objectMapper), Customizer.withDefaults())


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호
#103 
## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
* 거래내역 조회 API 구현

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
* totalAmount 보다 기존의 totalMoney 네이밍이 더 적절한 것 같아서 수정했습니다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 팀 주문 목록 조회 엔드포인트 추가: GET /team/orders (인증된 본인 팀 기준, STUDENT 권한 필요). 주문 항목에 id, itemId, itemName, itemPrice, orderCount, totalMoney, orderType, invCount 포함 반환.
* **Refactor**
  * 금액 필드명 통일: totalAmount → totalMoney (요청/응답/도메인). 클라이언트는 요청 바디에 totalMoney 사용 필요.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->