### PR TITLE
Merge/mzbe 152 get lesson item

### DIFF
--- a/src/main/kotlin/team/mozu/dsm/adapter/in/lesson/LessonWebAdapter.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/in/lesson/LessonWebAdapter.kt
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.DeleteMapping
 import team.mozu.dsm.adapter.`in`.lesson.dto.request.LessonRequest
+import team.mozu.dsm.adapter.`in`.lesson.dto.response.LessonItemResponse
 import team.mozu.dsm.adapter.`in`.lesson.dto.response.LessonListResponse
 import team.mozu.dsm.adapter.`in`.lesson.dto.response.LessonResponse
 import team.mozu.dsm.adapter.`in`.lesson.dto.response.StartLessonResponse
@@ -23,6 +24,7 @@ import team.mozu.dsm.application.port.`in`.lesson.EndLessonUseCase
 import team.mozu.dsm.application.port.`in`.lesson.UpdateLessonUseCase
 import team.mozu.dsm.application.port.`in`.lesson.GetLessonDetailUseCase
 import team.mozu.dsm.application.port.`in`.lesson.GetLessonsUseCase
+import team.mozu.dsm.application.port.`in`.lesson.GetLessonItemsUseCase
 import java.util.UUID
 
 @RestController
@@ -35,7 +37,8 @@ class LessonWebAdapter(
     private val endLessonUseCase: EndLessonUseCase,
     private val updateLessonUseCase: UpdateLessonUseCase,
     private val getLessonDetailUseCase: GetLessonDetailUseCase,
-    private val getLessonsUseCase: GetLessonsUseCase
+    private val getLessonsUseCase: GetLessonsUseCase,
+    private val getLessonItemsUseCase: GetLessonItemsUseCase
 ) {
 
     @PostMapping
@@ -101,5 +104,13 @@ class LessonWebAdapter(
     @ResponseStatus(HttpStatus.OK)
     fun get(): LessonListResponse {
         return getLessonsUseCase.get()
+    }
+
+    @GetMapping("/items/{lesson-id}")
+    @ResponseStatus(HttpStatus.OK)
+    fun getLessonItems(
+        @PathVariable("lesson-id") lessonId: UUID
+    ): List<LessonItemResponse> {
+        return getLessonItemsUseCase.get(lessonId)
     }
 }

--- a/src/main/kotlin/team/mozu/dsm/adapter/out/organ/persistence/OrganPersistenceAdapter.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/out/organ/persistence/OrganPersistenceAdapter.kt
@@ -13,7 +13,7 @@ import team.mozu.dsm.adapter.out.organ.persistence.repository.OrganRepository
 import team.mozu.dsm.application.port.out.organ.CommandOrganPort
 import team.mozu.dsm.application.port.out.organ.QueryOrganPort
 import team.mozu.dsm.domain.organ.model.Organ
-import java.util.UUID
+import java.util.*
 
 @Component
 class OrganPersistenceAdapter(

--- a/src/main/kotlin/team/mozu/dsm/application/port/in/lesson/GetLessonItemsUseCase.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/port/in/lesson/GetLessonItemsUseCase.kt
@@ -1,0 +1,9 @@
+package team.mozu.dsm.application.port.`in`.lesson
+
+import team.mozu.dsm.adapter.`in`.lesson.dto.response.LessonItemResponse
+import java.util.UUID
+
+interface GetLessonItemsUseCase {
+
+    fun get(lessonId: UUID): List<LessonItemResponse>
+}

--- a/src/main/kotlin/team/mozu/dsm/application/service/lesson/GetLessonItemsService.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/service/lesson/GetLessonItemsService.kt
@@ -1,0 +1,21 @@
+package team.mozu.dsm.application.service.lesson
+
+import org.springframework.stereotype.Service
+import team.mozu.dsm.adapter.`in`.lesson.dto.response.LessonItemResponse
+import team.mozu.dsm.application.port.`in`.lesson.GetLessonItemsUseCase
+import team.mozu.dsm.application.port.out.lesson.QueryLessonItemPort
+import team.mozu.dsm.application.service.lesson.facade.LessonFacade
+import java.util.UUID
+
+@Service
+class GetLessonItemsService(
+    private val lessonItemPort: QueryLessonItemPort,
+    private val lessonFacade: LessonFacade
+): GetLessonItemsUseCase {
+
+    override fun get(lessonId: UUID): List<LessonItemResponse> {
+        val lessonItems = lessonItemPort.findAllByLessonId(lessonId)
+
+        return lessonFacade.toLessonItemResponses(lessonItems)
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

- #105 

## 📝작업 내용
수업 종목 조회 API

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 스크린샷 (선택)
<img width="1608" height="1280" alt="image" src="https://github.com/user-attachments/assets/90ce171b-05d4-4093-9c0e-6c1eb45a2d52" />


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 레슨 아이템 조회용 GET API 추가: /lesson/items/{lesson-id}. 지정한 레슨 ID의 아이템 목록을 반환합니다.
  - 응답은 200 OK와 함께 아이템 리스트를 제공하며, 데이터가 없으면 빈 배열을 반환합니다.
  - 기존 레슨 관련 엔드포인트는 변경 없이 유지되어 기존 클라이언트와의 호환성에 영향이 없습니다.
  - 인증/권한 정책은 기존 레슨 API와 동일하게 적용됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->