### PR TITLE
Merge/mzbe 139 query item

### DIFF
--- a/src/main/kotlin/team/mozu/dsm/adapter/in/item/ItemWebAdapter.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/in/item/ItemWebAdapter.kt
@@ -2,19 +2,21 @@ package team.mozu.dsm.adapter.`in`.item
 
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.ResponseStatus
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 import team.mozu.dsm.adapter.`in`.item.dto.request.ItemRequest
 import team.mozu.dsm.adapter.`in`.item.dto.response.ItemResponse
 import team.mozu.dsm.application.port.`in`.item.CreateItemUseCase
+import team.mozu.dsm.application.port.`in`.item.QueryItemAllUseCase
+import team.mozu.dsm.application.port.`in`.item.QueryItemDetailUseCase
+import team.mozu.dsm.application.service.item.QueryItemDetailService
+import java.util.*
 
 @RestController
 @RequestMapping("item")
 class ItemWebAdapter (
-    private val createItemUseCase: CreateItemUseCase
+    private val createItemUseCase: CreateItemUseCase,
+    private val queryItemDetailUseCase: QueryItemDetailUseCase,
+    private val queryItemAllUseCase: QueryItemAllUseCase
 ){
 
     @PostMapping("/create")
@@ -24,5 +26,17 @@ class ItemWebAdapter (
         request: ItemRequest
     ) : ItemResponse {
         return createItemUseCase.create(request)
+    }
+
+    @GetMapping("/{id}")
+    fun queryDetail(
+        @PathVariable id: UUID
+    ): ItemResponse {
+        return queryItemDetailUseCase.queryDetail(id)
+    }
+
+    @GetMapping
+    fun queryAll(): List<ItemResponse> {
+        return queryItemAllUseCase.queryAll()
     }
 }

--- a/src/main/kotlin/team/mozu/dsm/adapter/in/item/ItemWebAdapter.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/in/item/ItemWebAdapter.kt
@@ -5,6 +5,7 @@ import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.*
 import team.mozu.dsm.adapter.`in`.item.dto.request.ItemRequest
 import team.mozu.dsm.adapter.`in`.item.dto.response.ItemResponse
+import team.mozu.dsm.adapter.out.item.persistence.mapper.ItemMapper
 import team.mozu.dsm.application.port.`in`.item.CreateItemUseCase
 import team.mozu.dsm.application.port.`in`.item.QueryItemAllUseCase
 import team.mozu.dsm.application.port.`in`.item.QueryItemDetailUseCase
@@ -16,7 +17,8 @@ import java.util.*
 class ItemWebAdapter (
     private val createItemUseCase: CreateItemUseCase,
     private val queryItemDetailUseCase: QueryItemDetailUseCase,
-    private val queryItemAllUseCase: QueryItemAllUseCase
+    private val queryItemAllUseCase: QueryItemAllUseCase,
+    private val itemMapper: ItemMapper
 ){
 
     @PostMapping("/create")
@@ -32,7 +34,8 @@ class ItemWebAdapter (
     fun queryDetail(
         @PathVariable id: UUID
     ): ItemResponse {
-        return queryItemDetailUseCase.queryDetail(id)
+        val item = queryItemDetailUseCase.queryDetail(id)
+        return itemMapper.toResponse(item)
     }
 
     @GetMapping

--- a/src/main/kotlin/team/mozu/dsm/adapter/in/item/ItemWebAdapter.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/in/item/ItemWebAdapter.kt
@@ -31,6 +31,7 @@ class ItemWebAdapter (
     }
 
     @GetMapping("/{id}")
+    @ResponseStatus(HttpStatus.OK)
     fun queryDetail(
         @PathVariable id: UUID
     ): ItemResponse {
@@ -39,6 +40,7 @@ class ItemWebAdapter (
     }
 
     @GetMapping
+    @ResponseStatus(HttpStatus.OK)
     fun queryAll(): List<ItemResponse> {
         return queryItemAllUseCase.queryAll()
     }

--- a/src/main/kotlin/team/mozu/dsm/adapter/in/item/dto/response/ItemResponse.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/in/item/dto/response/ItemResponse.kt
@@ -4,11 +4,11 @@ import com.fasterxml.jackson.annotation.JsonFormat
 import java.time.LocalDateTime
 import java.util.*
 
-data class ItemResponse (
+data class ItemResponse(
     val id: UUID,
-    val name: String,
-    val logo: String? = null,
-    val info: String,
+    val itemName: String,
+    val itemLogo: String? = null,
+    val itemInfo: String,
     val money: Int,
     val debt: Int,
     val capital: Int,

--- a/src/main/kotlin/team/mozu/dsm/adapter/out/item/persistence/ItemPersistenceAdapter.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/out/item/persistence/ItemPersistenceAdapter.kt
@@ -28,6 +28,16 @@ class ItemPersistenceAdapter(
             .map { itemMapper.toModel(it) }
     }
 
+    override fun findById(id: UUID): Item? {
+        return itemRepository.findByIdOrNull(id)
+            ?.let { itemMapper.toModel(it) }
+    }
+
+    override fun findAll(): List<Item> {
+        return itemRepository.findAll()
+            .map { itemMapper.toModel(it) }
+    }
+
     //--Command--//
     override fun save(item: Item): Item {
         val organ = organRepository.findByIdOrNull(item.organId)

--- a/src/main/kotlin/team/mozu/dsm/adapter/out/item/persistence/mapper/ItemMapper.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/out/item/persistence/mapper/ItemMapper.kt
@@ -2,6 +2,7 @@ package team.mozu.dsm.adapter.out.item.persistence.mapper
 
 import org.mapstruct.Mapper
 import org.mapstruct.Mapping
+import team.mozu.dsm.adapter.`in`.item.dto.response.ItemResponse
 import team.mozu.dsm.adapter.out.item.entity.ItemJpaEntity
 import team.mozu.dsm.adapter.out.organ.entity.OrganJpaEntity
 import team.mozu.dsm.domain.item.model.Item
@@ -11,6 +12,8 @@ abstract class ItemMapper {
 
     @Mapping(target = "organId", source = "organ.id")
     abstract fun toModel(entity: ItemJpaEntity): Item
+
+    abstract fun toResponse(model: Item) : ItemResponse
 
     fun toEntity(model: Item, organ: OrganJpaEntity): ItemJpaEntity {
         return ItemJpaEntity(

--- a/src/main/kotlin/team/mozu/dsm/application/port/in/item/QueryItemAllUseCase.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/port/in/item/QueryItemAllUseCase.kt
@@ -1,0 +1,7 @@
+package team.mozu.dsm.application.port.`in`.item
+
+import team.mozu.dsm.adapter.`in`.item.dto.response.ItemResponse
+
+interface QueryItemAllUseCase {
+    fun queryAll() : List<ItemResponse>
+}

--- a/src/main/kotlin/team/mozu/dsm/application/port/in/item/QueryItemDetailUseCase.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/port/in/item/QueryItemDetailUseCase.kt
@@ -1,9 +1,8 @@
 package team.mozu.dsm.application.port.`in`.item
 
-import team.mozu.dsm.adapter.`in`.item.dto.response.ItemResponse
+import team.mozu.dsm.domain.item.model.Item
 import java.util.UUID
 
 interface QueryItemDetailUseCase {
-    fun queryDetail(id :UUID) : ItemResponse
-
+    fun queryDetail(id :UUID) : Item
 }

--- a/src/main/kotlin/team/mozu/dsm/application/port/in/item/QueryItemDetailUseCase.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/port/in/item/QueryItemDetailUseCase.kt
@@ -1,0 +1,9 @@
+package team.mozu.dsm.application.port.`in`.item
+
+import team.mozu.dsm.adapter.`in`.item.dto.response.ItemResponse
+import java.util.UUID
+
+interface QueryItemDetailUseCase {
+    fun queryDetail(id :UUID) : ItemResponse
+
+}

--- a/src/main/kotlin/team/mozu/dsm/application/port/out/item/QueryItemPort.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/port/out/item/QueryItemPort.kt
@@ -8,4 +8,8 @@ interface QueryItemPort {
     fun existsById(id: UUID): Boolean
 
     fun findAllByIds(ids: List<UUID>): List<Item>
+
+    fun findById(id : UUID): Item?
+
+    fun findAll(): List<Item>
 }

--- a/src/main/kotlin/team/mozu/dsm/application/service/item/CreateItemService.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/service/item/CreateItemService.kt
@@ -43,9 +43,9 @@ class CreateItemService (
 
         return ItemResponse(
             id = saved.id!!,
-            name = saved.itemName,
-            logo = saved.itemLogo,
-            info = saved.itemInfo,
+            itemName = saved.itemName,
+            itemLogo = saved.itemLogo,
+            itemInfo = saved.itemInfo,
             money = saved.money,
             debt = saved.debt,
             capital = saved.capital,

--- a/src/main/kotlin/team/mozu/dsm/application/service/item/CreateItemService.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/service/item/CreateItemService.kt
@@ -4,6 +4,7 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import team.mozu.dsm.adapter.`in`.item.dto.request.ItemRequest
 import team.mozu.dsm.adapter.`in`.item.dto.response.ItemResponse
+import team.mozu.dsm.adapter.out.item.persistence.mapper.ItemMapper
 import team.mozu.dsm.application.port.`in`.item.CreateItemUseCase
 import team.mozu.dsm.application.port.out.auth.SecurityPort
 import team.mozu.dsm.application.port.out.item.CommandItemPort
@@ -14,7 +15,8 @@ import java.util.*
 @Service
 class CreateItemService (
     private val securityPort: SecurityPort,
-    private val itemPort: CommandItemPort
+    private val itemPort: CommandItemPort,
+    private val itemMapper: ItemMapper
 ) : CreateItemUseCase {
 
     @Transactional
@@ -41,20 +43,6 @@ class CreateItemService (
 
         val saved = itemPort.save(item)
 
-        return ItemResponse(
-            id = saved.id!!,
-            itemName = saved.itemName,
-            itemLogo = saved.itemLogo,
-            itemInfo = saved.itemInfo,
-            money = saved.money,
-            debt = saved.debt,
-            capital = saved.capital,
-            profit = saved.profit,
-            profitOg = saved.profitOg,
-            profitBenefit = saved.profitBenefit,
-            netProfit = saved.netProfit,
-            isDeleted = saved.isDeleted,
-            createdAt = saved.createdAt
-        )
+        return itemMapper.toResponse(saved)
     }
 }

--- a/src/main/kotlin/team/mozu/dsm/application/service/item/QueryItemAllService.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/service/item/QueryItemAllService.kt
@@ -13,7 +13,7 @@ class QueryItemAllService (
     private val itemMapper: ItemMapper
 ) : QueryItemAllUseCase{
 
-    @Transactional
+    @Transactional(readOnly = true)
     override fun queryAll(): List<ItemResponse> {
         return queryItemPort.findAll().map {itemMapper.toResponse(it)}
     }

--- a/src/main/kotlin/team/mozu/dsm/application/service/item/QueryItemAllService.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/service/item/QueryItemAllService.kt
@@ -1,0 +1,20 @@
+package team.mozu.dsm.application.service.item
+
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import team.mozu.dsm.adapter.`in`.item.dto.response.ItemResponse
+import team.mozu.dsm.adapter.out.item.persistence.mapper.ItemMapper
+import team.mozu.dsm.application.port.`in`.item.QueryItemAllUseCase
+import team.mozu.dsm.application.port.out.item.QueryItemPort
+
+@Service
+class QueryItemAllService (
+    private val queryItemPort: QueryItemPort,
+    private val itemMapper: ItemMapper
+) : QueryItemAllUseCase{
+
+    @Transactional
+    override fun queryAll(): List<ItemResponse> {
+        return queryItemPort.findAll().map {itemMapper.toResponse(it)}
+    }
+}

--- a/src/main/kotlin/team/mozu/dsm/application/service/item/QueryItemDetailService.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/service/item/QueryItemDetailService.kt
@@ -2,24 +2,20 @@ package team.mozu.dsm.application.service.item
 
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import team.mozu.dsm.adapter.`in`.item.dto.response.ItemResponse
-import team.mozu.dsm.adapter.out.item.persistence.mapper.ItemMapper
 import team.mozu.dsm.application.exception.item.ItemNotFoundException
 import team.mozu.dsm.application.port.`in`.item.QueryItemDetailUseCase
 import team.mozu.dsm.application.port.out.item.QueryItemPort
+import team.mozu.dsm.domain.item.model.Item
 import java.util.*
 
 @Service
 class QueryItemDetailService (
     private val queryItemPort: QueryItemPort,
-    private val itemMapper: ItemMapper
 ) : QueryItemDetailUseCase {
 
     @Transactional
-    override fun queryDetail(id: UUID): ItemResponse {
-        val item = queryItemPort.findById(id)
+    override fun queryDetail(id: UUID): Item {
+        return queryItemPort.findById(id)
             ?: throw ItemNotFoundException
-
-        return itemMapper.toResponse(item)
     }
 }

--- a/src/main/kotlin/team/mozu/dsm/application/service/item/QueryItemDetailService.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/service/item/QueryItemDetailService.kt
@@ -13,7 +13,7 @@ class QueryItemDetailService (
     private val queryItemPort: QueryItemPort,
 ) : QueryItemDetailUseCase {
 
-    @Transactional
+    @Transactional(readOnly = true)
     override fun queryDetail(id: UUID): Item {
         return queryItemPort.findById(id)
             ?: throw ItemNotFoundException

--- a/src/main/kotlin/team/mozu/dsm/application/service/item/QueryItemDetailService.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/service/item/QueryItemDetailService.kt
@@ -1,0 +1,25 @@
+package team.mozu.dsm.application.service.item
+
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import team.mozu.dsm.adapter.`in`.item.dto.response.ItemResponse
+import team.mozu.dsm.adapter.out.item.persistence.mapper.ItemMapper
+import team.mozu.dsm.application.exception.item.ItemNotFoundException
+import team.mozu.dsm.application.port.`in`.item.QueryItemDetailUseCase
+import team.mozu.dsm.application.port.out.item.QueryItemPort
+import java.util.*
+
+@Service
+class QueryItemDetailService (
+    private val queryItemPort: QueryItemPort,
+    private val itemMapper: ItemMapper
+) : QueryItemDetailUseCase {
+
+    @Transactional
+    override fun queryDetail(id: UUID): ItemResponse {
+        val item = queryItemPort.findById(id)
+            ?: throw ItemNotFoundException
+
+        return itemMapper.toResponse(item)
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #96 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/ed28a835-b958-4c95-bf89-86bdd3d55876" />

<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/e1e153b9-a374-42c2-8759-e199eabd7f45" />
 - 전체조회, 개별조회 기능 개발

## 💬리뷰 요구사항(선택)

- 조회로 이슈를 파버려서 개별조회, 전체조회 기능을 한 번에 pr 날립니다... 혹여 나눠야 했던거라면 죄삼다..


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 아이템 조회 API 추가: GET /item (전체 목록), GET /item/{id} (단건 상세 조회).
  - 아이템 생성 API: POST /create 사용 시 201 Created 반환 유지.
- 호환성 변경
  - 응답 필드명 변경: name → itemName, logo → itemLogo, info → itemInfo. 클라이언트 매핑 업데이트 필요.
- 기타
  - 서버에서 전체/단건 조회를 직접 제공하여 클라이언트 조회 로직 단순화 가능.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->