### PR TITLE
Merge/mzbe 145 get team rank

### DIFF
--- a/src/main/kotlin/team/mozu/dsm/adapter/in/team/TeamWebAdapter.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/in/team/TeamWebAdapter.kt
@@ -11,17 +11,19 @@ import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 import team.mozu.dsm.adapter.`in`.team.dto.request.CompleteInvestmentRequest
 import team.mozu.dsm.adapter.`in`.team.dto.request.TeamParticipationRequest
+import team.mozu.dsm.adapter.`in`.team.dto.response.TeamRankResponse
+import team.mozu.dsm.adapter.`in`.team.dto.response.TeamResultResponse
 import team.mozu.dsm.adapter.`in`.team.dto.response.TeamTokenResponse
 import team.mozu.dsm.adapter.`in`.team.dto.response.StockResponse
 import team.mozu.dsm.adapter.`in`.team.dto.response.TeamDetailResponse
 import team.mozu.dsm.adapter.`in`.team.dto.response.OrderItemResponse
-import team.mozu.dsm.adapter.`in`.team.dto.response.TeamResultResponse
 import team.mozu.dsm.application.port.`in`.team.TeamParticipationUseCase
 import team.mozu.dsm.application.port.`in`.team.CompleteTeamInvestmentUseCase
 import team.mozu.dsm.application.port.`in`.team.GetStocksUseCase
 import team.mozu.dsm.application.port.`in`.team.GetTeamDetailUseCase
 import team.mozu.dsm.application.port.`in`.team.GetOrderItemUseCase
 import team.mozu.dsm.application.port.`in`.team.GetTeamResultUseCase
+import team.mozu.dsm.application.port.`in`.team.GetTeamRanksUseCase
 import team.mozu.dsm.global.security.auth.StudentPrincipal
 
 @RestController
@@ -32,7 +34,8 @@ class TeamWebAdapter(
     private val getStocksUseCase: GetStocksUseCase,
     private val getTeamDetailUseCase: GetTeamDetailUseCase,
     private val getOrderItemUseCase: GetOrderItemUseCase,
-    private val getTeamResultUseCase: GetTeamResultUseCase
+    private val getTeamResultUseCase: GetTeamResultUseCase,
+    private val getTeamRanksUseCase: GetTeamRanksUseCase
 ) {
     @PostMapping("/participate")
     @ResponseStatus(HttpStatus.CREATED)
@@ -83,5 +86,13 @@ class TeamWebAdapter(
         @AuthenticationPrincipal principal: StudentPrincipal
     ): TeamResultResponse {
         return getTeamResultUseCase.get(principal.lessonNum ,principal.teamId)
+    }
+
+    @GetMapping("/rank")
+    @ResponseStatus(HttpStatus.OK)
+    fun getRank(
+        @AuthenticationPrincipal principal: StudentPrincipal
+    ): List<TeamRankResponse> {
+        return getTeamRanksUseCase.get(principal.lessonNum ,principal.teamId)
     }
 }

--- a/src/main/kotlin/team/mozu/dsm/adapter/in/team/TeamWebAdapter.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/in/team/TeamWebAdapter.kt
@@ -88,7 +88,7 @@ class TeamWebAdapter(
         return getTeamResultUseCase.get(principal.lessonNum ,principal.teamId)
     }
 
-    @GetMapping("/rank")
+    @GetMapping("/ranks")
     @ResponseStatus(HttpStatus.OK)
     fun getRank(
         @AuthenticationPrincipal principal: StudentPrincipal

--- a/src/main/kotlin/team/mozu/dsm/adapter/in/team/dto/response/TeamRankResponse.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/in/team/dto/response/TeamRankResponse.kt
@@ -1,0 +1,11 @@
+package team.mozu.dsm.adapter.`in`.team.dto.response
+
+import java.util.UUID
+
+data class TeamRankResponse(
+    val id: UUID,
+    val teamName: String?,
+    val schoolName: String,
+    val totalMoney: Int,
+    val isMyTeam: Boolean
+)

--- a/src/main/kotlin/team/mozu/dsm/adapter/out/team/persistence/TeamPersistenceAdapter.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/out/team/persistence/TeamPersistenceAdapter.kt
@@ -41,6 +41,16 @@ class TeamPersistenceAdapter(
         return entity?.let { teamMapper.toModel(it) }
     }
 
+    override fun findAllByLessonNumOrderByTotalMoneyDesc(lessonNum: String): List<Team> {
+        val entities = jpaQueryFactory
+            .selectFrom(teamJpaEntity)
+            .where(teamJpaEntity.lessonNum.eq(lessonNum))
+            .orderBy(teamJpaEntity.totalMoney.desc())
+            .fetch()
+
+        return entities.map { teamMapper.toModel(it) }
+    }
+
     //--Command--//
     override fun create(team: Team): Team {
         val lessonEntity = lessonRepository.findByIdOrNull(team.lessonId)

--- a/src/main/kotlin/team/mozu/dsm/application/port/in/team/GetTeamRanksUseCase.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/port/in/team/GetTeamRanksUseCase.kt
@@ -1,0 +1,9 @@
+package team.mozu.dsm.application.port.`in`.team
+
+import team.mozu.dsm.adapter.`in`.team.dto.response.TeamRankResponse
+import java.util.UUID
+
+interface GetTeamRanksUseCase {
+
+    fun get(lessonNum: String, teamId: UUID): List<TeamRankResponse>
+}

--- a/src/main/kotlin/team/mozu/dsm/application/port/out/item/QueryItemPort.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/port/out/item/QueryItemPort.kt
@@ -7,7 +7,7 @@ interface QueryItemPort {
 
     fun existsById(id: UUID): Boolean
 
-    fun findAllByIds(ids: List<UUID>): List<Item>
+    fun findAllByIds(ids: Set<UUID>): List<Item>
 
     fun findById(id : UUID): Item?
 

--- a/src/main/kotlin/team/mozu/dsm/application/port/out/team/QueryTeamPort.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/port/out/team/QueryTeamPort.kt
@@ -8,4 +8,6 @@ interface QueryTeamPort {
     fun findById(teamId: UUID): Team
 
     fun findByIdWithLock(teamId: UUID): Team?
+
+    fun findAllByLessonNumOrderByTotalMoneyDesc(lessonNum: String): List<Team>
 }

--- a/src/main/kotlin/team/mozu/dsm/application/service/team/CompleteTeamInvestmentService.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/service/team/CompleteTeamInvestmentService.kt
@@ -81,9 +81,9 @@ class CompleteTeamInvestmentService(
         }
         commandOrderItemPort.saveAll(orderItems)
 
-        updateStocksAndTeam(requests, team)
-
         updatePreviouslyTradedStocksProfit(teamId, lesson, requests.map { it.itemId })
+
+        updateStocksAndTeam(requests, team)
 
         TransactionSynchronizationManager.registerSynchronization(
             object : TransactionSynchronization {
@@ -379,7 +379,7 @@ class CompleteTeamInvestmentService(
         // 평가액 = 보유 수량 * 주식의 현재가
         val valuationMoney = currentStocks.sumOf { stock ->
             val lessonItem = stockLessonItemMap[stock.itemId] ?: throw LessonItemNotFoundException
-            val currentPrice = lessonItem.getPriceByRound(curInvRound) ?: lessonItem.currentMoney ?: 0
+            val currentPrice = lessonItem.getPriceByRound(curInvRound) ?: lessonItem.currentMoney
             currentPrice * stock.quantity
         }
 
@@ -400,7 +400,7 @@ class CompleteTeamInvestmentService(
         val lessonId = lesson.id ?: throw LessonNotFoundException
         val currentRound = lesson.curInvRound
 
-        val allStocks = queryStockPort.findAllByTeamId(teamId).filterNotNull()
+        val allStocks = queryStockPort.findAllByTeamId(teamId)
 
         val nonTradedStocks = allStocks.filter { stock ->
             stock.itemId !in tradedItemIds
@@ -414,7 +414,7 @@ class CompleteTeamInvestmentService(
 
         val stocksToUpdate = nonTradedStocks.map { stock ->
             val lessonItem = lessonItemMap[stock.itemId] ?: throw LessonItemNotFoundException
-            val currentPrice = lessonItem.getPriceByRound(currentRound) ?: lessonItem.currentMoney ?: 0
+            val currentPrice = lessonItem.getPriceByRound(currentRound) ?: lessonItem.currentMoney
 
             val currentValProfit = (currentPrice * stock.quantity) - stock.buyMoney
             val currentProfitNum = if (stock.buyMoney > 0) {

--- a/src/main/kotlin/team/mozu/dsm/application/service/team/GetTeamRanksService.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/service/team/GetTeamRanksService.kt
@@ -1,0 +1,29 @@
+package team.mozu.dsm.application.service.team
+
+import org.springframework.stereotype.Service
+import team.mozu.dsm.adapter.`in`.team.dto.response.TeamRankResponse
+import team.mozu.dsm.application.port.`in`.team.GetTeamRanksUseCase
+import team.mozu.dsm.application.port.out.team.QueryTeamPort
+import java.util.UUID
+
+@Service
+class GetTeamRanksService(
+    private val queryTeamPort: QueryTeamPort
+) : GetTeamRanksUseCase {
+
+    override fun get(lessonNum: String, teamId: UUID): List<TeamRankResponse> {
+
+        val allTeams = queryTeamPort.findAllByLessonNumOrderByTotalMoneyDesc(lessonNum)
+
+        return allTeams
+            .map { team ->
+                TeamRankResponse(
+                    id = team.id!!,
+                    teamName = team.teamName,
+                    schoolName = team.schoolName,
+                    totalMoney = team.totalMoney,
+                    isMyTeam = team.id == teamId
+                )
+            }
+    }
+}

--- a/src/main/kotlin/team/mozu/dsm/application/service/team/GetTeamRanksService.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/service/team/GetTeamRanksService.kt
@@ -1,6 +1,7 @@
 package team.mozu.dsm.application.service.team
 
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 import team.mozu.dsm.adapter.`in`.team.dto.response.TeamRankResponse
 import team.mozu.dsm.application.port.`in`.team.GetTeamRanksUseCase
 import team.mozu.dsm.application.port.out.team.QueryTeamPort
@@ -11,6 +12,7 @@ class GetTeamRanksService(
     private val queryTeamPort: QueryTeamPort
 ) : GetTeamRanksUseCase {
 
+    @Transactional(readOnly = true)
     override fun get(lessonNum: String, teamId: UUID): List<TeamRankResponse> {
 
         val allTeams = queryTeamPort.findAllByLessonNumOrderByTotalMoneyDesc(lessonNum)

--- a/src/main/kotlin/team/mozu/dsm/application/service/team/GetTeamResultService.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/service/team/GetTeamResultService.kt
@@ -1,6 +1,7 @@
 package team.mozu.dsm.application.service.team
 
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 import team.mozu.dsm.adapter.`in`.team.dto.response.TeamResultResponse
 import team.mozu.dsm.application.exception.lesson.LessonItemNotFoundException
 import team.mozu.dsm.application.exception.lesson.LessonNotFoundException
@@ -21,6 +22,7 @@ class GetTeamResultService(
     private val queryOrderItemPort: QueryOrderItemPort
 ) : GetTeamResultUseCase {
 
+    @Transactional(readOnly = true)
     override fun get(lessonNum: String, teamId: UUID): TeamResultResponse {
 
         val lesson = queryLessonPort.findByLessonNum(lessonNum)

--- a/src/main/kotlin/team/mozu/dsm/global/config/security/SecurityConfig.kt
+++ b/src/main/kotlin/team/mozu/dsm/global/config/security/SecurityConfig.kt
@@ -53,6 +53,7 @@ class SecurityConfig(
                 it.requestMatchers(HttpMethod.GET, "/team/detail").hasAnyRole("STUDENT")
                 it.requestMatchers(HttpMethod.GET, "/team/orders").hasAnyRole("STUDENT")
                 it.requestMatchers(HttpMethod.GET, "/team/result").hasAnyRole("STUDENT")
+                it.requestMatchers(HttpMethod.GET, "/team/rank").hasAnyRole("STUDENT")
                     .anyRequest().authenticated()
             }
             .with(FilterConfig(jwtTokenProvider, objectMapper), Customizer.withDefaults())


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호
#118 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
*팀 랭킹 조회 api 구현
### 스크린샷 (선택)
<img width="850" height="638" alt="image" src="https://github.com/user-attachments/assets/cf83144a-f80a-4425-a73d-ae8641a73ae3" />

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 팀 순위 조회가 추가되어 학생이 수업별 팀 순위를 확인할 수 있으며, 목록에서 ‘내 팀’이 구분 표시됩니다.
- 버그 수정
  - 투자 정산 과정의 가격·평가 금액 산정 로직을 정비해 일부 상황에서 발생하던 계산 불일치를 개선했습니다.
- 기타(작업)
  - 팀 순위 조회 경로에 학생 권한을 요구하도록 접근 제어를 강화했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->