### PR TITLE
Merge/mzbe 166 lesson organ sse connection

### DIFF
--- a/src/main/kotlin/team/mozu/dsm/adapter/in/item/ItemWebAdapter.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/in/item/ItemWebAdapter.kt
@@ -46,6 +46,7 @@ class ItemWebAdapter (
     @ResponseStatus(HttpStatus.OK)
     fun queryAll(): List<ItemResponse> {
         return queryItemAllUseCase.queryAll()
+    }
         
     @DeleteMapping("/{id}")
     @ResponseStatus(HttpStatus.NO_CONTENT)

--- a/src/main/kotlin/team/mozu/dsm/adapter/in/lesson/LessonWebAdapter.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/in/lesson/LessonWebAdapter.kt
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter
 import team.mozu.dsm.adapter.`in`.lesson.dto.request.LessonRequest
 import team.mozu.dsm.adapter.`in`.lesson.dto.response.LessonItemResponse
 import team.mozu.dsm.adapter.`in`.lesson.dto.response.LessonListResponse
@@ -28,6 +29,7 @@ import team.mozu.dsm.application.port.`in`.lesson.GetLessonsUseCase
 import team.mozu.dsm.application.port.`in`.lesson.GetLessonItemsUseCase
 import team.mozu.dsm.application.port.`in`.lesson.GetLessonArticlesUseCase
 import team.mozu.dsm.application.port.`in`.lesson.NextLessonUseCase
+import team.mozu.dsm.application.port.`in`.lesson.LessonOrganSSEUseCase
 import java.util.UUID
 
 @RestController
@@ -43,7 +45,8 @@ class LessonWebAdapter(
     private val getLessonsUseCase: GetLessonsUseCase,
     private val getLessonItemsUseCase: GetLessonItemsUseCase,
     private val getLessonArticlesUseCase: GetLessonArticlesUseCase,
-    private val nextLessonUseCase: NextLessonUseCase
+    private val nextLessonUseCase: NextLessonUseCase,
+    private val lessonOrganSSEUseCase: LessonOrganSSEUseCase
 ) {
 
     @PostMapping
@@ -133,5 +136,13 @@ class LessonWebAdapter(
         @PathVariable("lesson-id") lessonId: UUID
     ) {
         nextLessonUseCase.next(lessonId)
+    }
+
+    @GetMapping("/sse/{lesson-id}")
+    @ResponseStatus(HttpStatus.OK)
+    fun sse(
+        @PathVariable("lesson-id") lessonId: UUID
+    ): SseEmitter {
+        return lessonOrganSSEUseCase.connect(lessonId)
     }
 }

--- a/src/main/kotlin/team/mozu/dsm/adapter/in/sse/dto/SSEResponse.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/in/sse/dto/SSEResponse.kt
@@ -1,0 +1,6 @@
+package team.mozu.dsm.adapter.`in`.sse.dto
+
+data class SSEResponse(
+    val type: String,
+    val message: String
+)

--- a/src/main/kotlin/team/mozu/dsm/adapter/out/team/persistence/TeamPersistenceAdapter.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/out/team/persistence/TeamPersistenceAdapter.kt
@@ -42,7 +42,7 @@ class TeamPersistenceAdapter(
     }
 
     override fun findAllByLessonId(lessonId: UUID): List<Team> {
-        val teams = queryFactory
+        val teams = jpaQueryFactory
             .selectFrom(teamJpaEntity)
             .where(
                 teamJpaEntity.lesson.id.eq(lessonId)

--- a/src/main/kotlin/team/mozu/dsm/application/port/in/lesson/LessonOrganSSEUseCase.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/port/in/lesson/LessonOrganSSEUseCase.kt
@@ -1,0 +1,9 @@
+package team.mozu.dsm.application.port.`in`.lesson
+
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter
+import java.util.UUID
+
+interface LessonOrganSSEUseCase {
+
+    fun connect(lessonId: UUID): SseEmitter
+}

--- a/src/main/kotlin/team/mozu/dsm/application/port/out/item/QueryItemPort.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/port/out/item/QueryItemPort.kt
@@ -7,7 +7,7 @@ interface QueryItemPort {
 
     fun existsById(id: UUID): Boolean
 
-    fun findAllByIds(ids: List<UUID>): List<Item>
+    fun findAllByIds(ids: Set<UUID>): List<Item>
 
     fun findById(id : UUID): Item?
 

--- a/src/main/kotlin/team/mozu/dsm/application/service/lesson/LessonOrganSSEService.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/service/lesson/LessonOrganSSEService.kt
@@ -1,0 +1,47 @@
+package team.mozu.dsm.application.service.lesson
+
+import org.springframework.stereotype.Service
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter
+import team.mozu.dsm.adapter.`in`.sse.dto.SSEResponse
+import team.mozu.dsm.application.exception.lesson.UnauthorizedLessonAccessException
+import team.mozu.dsm.application.port.`in`.lesson.LessonOrganSSEUseCase
+import team.mozu.dsm.application.port.out.auth.SecurityPort
+import team.mozu.dsm.application.port.out.sse.SubscribeSsePort
+import team.mozu.dsm.application.service.lesson.facade.LessonFacade
+import java.util.UUID
+
+@Service
+class LessonOrganSSEService(
+    private val subscribeSsePort: SubscribeSsePort,
+    private val lessonFacade: LessonFacade,
+    private val securityPort: SecurityPort
+): LessonOrganSSEUseCase {
+
+    companion object{
+        private const val CONNECTED_EVENT = "LESSON_SSE_CONNECTED"
+    }
+
+    override fun connect(lessonId: UUID): SseEmitter {
+        val lesson = lessonFacade.findByLessonId(lessonId)
+        val organ = securityPort.getCurrentOrgan()
+
+        if (lesson.organId != organ.id) {
+            throw UnauthorizedLessonAccessException
+        }
+
+        val clientId = "${lesson.id}:${organ.id}"
+        val emitter = subscribeSsePort.subscribe(clientId)
+
+        try {
+            emitter.send(
+                SseEmitter.event()
+                    .name(CONNECTED_EVENT)
+                    .data(SSEResponse(CONNECTED_EVENT, "id ${lesson.id}의 수업 기관 클라이언트 SSE 연결되었습니다."))
+            )
+        } catch (e: Exception) {
+            emitter.completeWithError(e)
+        }
+
+        return emitter
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

- #119 

## 📝작업 내용

- 수업 기관 SSE 연결 API 개발
<img width="798" height="479" alt="image" src="https://github.com/user-attachments/assets/5e664d79-4c2c-40ea-ab10-2fcd5e1562ed" />



## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
- 기존 API 명세서에서는 SSE 연결 시 message만 반환했는데, 다른 SSE 연결 API도 있어서 type 필드를 추가해 이벤트 이름을 명시했습니다.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 수업별 서버센트이벤트(SSE) 실시간 스트리밍 지원 추가. GET /sse/{lesson-id} 엔드포인트에서 연결 가능하며, 연결 시 초기 상태 이벤트가 전송됩니다. 기관 권한 검증을 통해 해당 수업 기관만 접속할 수 있습니다.
* 버그 수정
  * 컴파일 오류를 유발하던 구문 문제를 수정했습니다.
  * 데이터 조회 과정의 설정 오류를 바로잡아 조회 안정성과 일관성을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->