### PR TITLE
Merge/mzbe 171 get lesson round articles

### DIFF
--- a/src/main/kotlin/team/mozu/dsm/adapter/in/lesson/LessonWebAdapter.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/in/lesson/LessonWebAdapter.kt
@@ -20,6 +20,7 @@ import team.mozu.dsm.adapter.`in`.lesson.dto.response.LessonResponse
 import team.mozu.dsm.adapter.`in`.lesson.dto.response.StartLessonResponse
 import team.mozu.dsm.adapter.`in`.lesson.dto.response.LessonArticleResponse
 import team.mozu.dsm.adapter.`in`.lesson.dto.response.LessonRoundItemResponse
+import team.mozu.dsm.adapter.`in`.lesson.dto.response.LessonRoundArticleResponse
 import team.mozu.dsm.application.port.`in`.lesson.ChangeStarredUseCase
 import team.mozu.dsm.application.port.`in`.lesson.CreateLessonUseCase
 import team.mozu.dsm.application.port.`in`.lesson.DeleteLessonUseCase
@@ -31,9 +32,10 @@ import team.mozu.dsm.application.port.`in`.lesson.GetLessonsUseCase
 import team.mozu.dsm.application.port.`in`.lesson.GetLessonItemsUseCase
 import team.mozu.dsm.application.port.`in`.lesson.GetLessonArticlesUseCase
 import team.mozu.dsm.application.port.`in`.lesson.NextLessonUseCase
-import team.mozu.dsm.application.port.`in`.lesson.GetLessonRoundItemsUseCase
-import team.mozu.dsm.global.security.auth.StudentPrincipal
 import team.mozu.dsm.application.port.`in`.lesson.LessonOrganSSEUseCase
+import team.mozu.dsm.application.port.`in`.lesson.GetLessonRoundItemsUseCase
+import team.mozu.dsm.application.port.`in`.lesson.GetLessonRoundArticlesUseCase
+import team.mozu.dsm.global.security.auth.StudentPrincipal
 import java.util.UUID
 
 @RestController
@@ -51,7 +53,8 @@ class LessonWebAdapter(
     private val getLessonArticlesUseCase: GetLessonArticlesUseCase,
     private val nextLessonUseCase: NextLessonUseCase,
     private val lessonOrganSSEUseCase: LessonOrganSSEUseCase,
-    private val getLessonRoundItemsUseCase: GetLessonRoundItemsUseCase
+    private val getLessonRoundItemsUseCase: GetLessonRoundItemsUseCase,
+    private val getLessonRoundArticlesUseCase: GetLessonRoundArticlesUseCase
 ) {
 
     @PostMapping
@@ -157,5 +160,13 @@ class LessonWebAdapter(
         @AuthenticationPrincipal studentPrincipal: StudentPrincipal
     ): List<LessonRoundItemResponse> {
         return getLessonRoundItemsUseCase.get(studentPrincipal.lessonNum)
+    }
+
+    @GetMapping("/team/articles")
+    @ResponseStatus(HttpStatus.OK)
+    fun getLessonRoundArticles(
+        @AuthenticationPrincipal studentPrincipal: StudentPrincipal
+    ): List<LessonRoundArticleResponse> {
+        return getLessonRoundArticlesUseCase.get(studentPrincipal.lessonNum)
     }
 }

--- a/src/main/kotlin/team/mozu/dsm/adapter/in/lesson/dto/response/LessonRoundArticleResponse.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/in/lesson/dto/response/LessonRoundArticleResponse.kt
@@ -1,0 +1,11 @@
+package team.mozu.dsm.adapter.`in`.lesson.dto.response
+
+import com.querydsl.core.annotations.QueryProjection
+import java.util.UUID
+
+data class LessonRoundArticleResponse @QueryProjection constructor(
+    val articleId: UUID,
+    val title: String,
+    val description: String,
+    val image: String?,
+)

--- a/src/main/kotlin/team/mozu/dsm/adapter/out/lesson/persistence/LessonArticlePersistenceAdapter.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/out/lesson/persistence/LessonArticlePersistenceAdapter.kt
@@ -2,8 +2,11 @@ package team.mozu.dsm.adapter.out.lesson.persistence
 
 import com.querydsl.jpa.impl.JPAQueryFactory
 import org.springframework.stereotype.Component
+import team.mozu.dsm.adapter.`in`.lesson.dto.response.LessonRoundArticleResponse
+import team.mozu.dsm.adapter.`in`.lesson.dto.response.QLessonRoundArticleResponse
 import team.mozu.dsm.adapter.out.article.persistence.repository.ArticleRepository
 import team.mozu.dsm.adapter.out.lesson.entity.QLessonArticleJpaEntity.lessonArticleJpaEntity
+import team.mozu.dsm.adapter.out.article.entity.QArticleJpaEntity.articleJpaEntity
 import team.mozu.dsm.adapter.out.lesson.persistence.mapper.LessonArticleMapper
 import team.mozu.dsm.adapter.out.lesson.persistence.repository.LessonArticleRepository
 import team.mozu.dsm.adapter.out.lesson.persistence.repository.LessonRepository
@@ -27,6 +30,25 @@ class LessonArticlePersistenceAdapter(
     override fun findAllByLessonId(lessonId: UUID): List<LessonArticle> {
         return lessonArticleRepository.findAllByLessonId(lessonId)
             .map { lessonArticleMapper.toModel(it) }
+    }
+
+    override fun findAllRoundArticlesByLessonId(lessonId: UUID, nowInvRound: Int): List<LessonRoundArticleResponse> {
+        return jpaQueryFactory
+            .select(
+                QLessonRoundArticleResponse(
+                    articleJpaEntity.id,
+                    articleJpaEntity.articleName,
+                    articleJpaEntity.articleDescription,
+                    articleJpaEntity.articleImage
+                )
+            )
+            .from(lessonArticleJpaEntity)
+            .join(lessonArticleJpaEntity.article, articleJpaEntity)
+            .where(
+                lessonArticleJpaEntity.lesson.id.eq(lessonId)
+                    .and(lessonArticleJpaEntity.investmentRound.eq(nowInvRound))
+            )
+            .fetch()
     }
 
     //--Command--//

--- a/src/main/kotlin/team/mozu/dsm/application/port/in/lesson/GetLessonRoundArticlesUseCase.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/port/in/lesson/GetLessonRoundArticlesUseCase.kt
@@ -1,0 +1,8 @@
+package team.mozu.dsm.application.port.`in`.lesson
+
+import team.mozu.dsm.adapter.`in`.lesson.dto.response.LessonRoundArticleResponse
+
+interface GetLessonRoundArticlesUseCase {
+
+    fun get(lessonNum: String): List<LessonRoundArticleResponse>
+}

--- a/src/main/kotlin/team/mozu/dsm/application/port/out/lesson/QueryLessonArticlePort.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/port/out/lesson/QueryLessonArticlePort.kt
@@ -1,9 +1,12 @@
 package team.mozu.dsm.application.port.out.lesson
 
+import team.mozu.dsm.adapter.`in`.lesson.dto.response.LessonRoundArticleResponse
 import team.mozu.dsm.domain.lesson.model.LessonArticle
 import java.util.*
 
 interface QueryLessonArticlePort {
 
     fun findAllByLessonId(lessonId: UUID): List<LessonArticle>
+
+    fun findAllRoundArticlesByLessonId(lessonId: UUID, nowInvRound: Int): List<LessonRoundArticleResponse>
 }

--- a/src/main/kotlin/team/mozu/dsm/application/service/lesson/GetLessonRoundArticlesService.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/service/lesson/GetLessonRoundArticlesService.kt
@@ -1,0 +1,25 @@
+package team.mozu.dsm.application.service.lesson
+
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import team.mozu.dsm.adapter.`in`.lesson.dto.response.LessonRoundArticleResponse
+import team.mozu.dsm.application.exception.lesson.LessonNotFoundException
+import team.mozu.dsm.application.port.`in`.lesson.GetLessonRoundArticlesUseCase
+import team.mozu.dsm.application.port.out.lesson.QueryLessonArticlePort
+import team.mozu.dsm.application.port.out.lesson.QueryLessonPort
+
+@Service
+class GetLessonRoundArticlesService(
+    private val lessonPort: QueryLessonPort,
+    private val lessonArticlePort: QueryLessonArticlePort
+): GetLessonRoundArticlesUseCase {
+
+    @Transactional(readOnly = true)
+    override fun get(lessonNum: String): List<LessonRoundArticleResponse> {
+        val lesson = lessonPort.findByLessonNum(lessonNum)
+            ?: throw LessonNotFoundException
+        val nowInvRound = lesson.curInvRound
+
+        return lessonArticlePort.findAllRoundArticlesByLessonId(lesson.id!!, nowInvRound)
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

- #127 

## 📝작업 내용
현재 차수에 해당하는 기사 목록 조회 API
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
<img width="1596" height="1202" alt="image" src="https://github.com/user-attachments/assets/98045780-b769-43dd-95ad-cef611bcfbc3" />


## 💬리뷰 요구사항(선택)
### 추후에 리팩토링 할 예정이니 로직 위주로 문제가 없는지 확인 부탁드립니다

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 수업 회차별 기사 목록 조회 API 추가: GET /team/articles. 로그인한 학생의 현재 수업·라운드에 해당하는 기사들을 반환합니다(기사 ID, 제목, 설명, 이미지). 학습 페이지 및 모바일/웹 클라이언트에서 회차별 콘텐츠를 빠르게 로드해 표시할 수 있습니다. 기존 라운드 아이템 조회와 유사한 방식으로 활용 가능합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->