### PR TITLE
Merge/mzbe 170 get lesson item detail

### DIFF
--- a/src/main/kotlin/team/mozu/dsm/adapter/in/lesson/LessonWebAdapter.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/in/lesson/LessonWebAdapter.kt
@@ -21,6 +21,7 @@ import team.mozu.dsm.adapter.`in`.lesson.dto.response.StartLessonResponse
 import team.mozu.dsm.adapter.`in`.lesson.dto.response.LessonArticleResponse
 import team.mozu.dsm.adapter.`in`.lesson.dto.response.LessonRoundItemResponse
 import team.mozu.dsm.adapter.`in`.lesson.dto.response.LessonRoundArticleResponse
+import team.mozu.dsm.adapter.`in`.lesson.dto.response.LessonItemDetailResponse
 import team.mozu.dsm.application.port.`in`.lesson.ChangeStarredUseCase
 import team.mozu.dsm.application.port.`in`.lesson.CreateLessonUseCase
 import team.mozu.dsm.application.port.`in`.lesson.DeleteLessonUseCase
@@ -35,6 +36,7 @@ import team.mozu.dsm.application.port.`in`.lesson.NextLessonUseCase
 import team.mozu.dsm.application.port.`in`.lesson.LessonOrganSSEUseCase
 import team.mozu.dsm.application.port.`in`.lesson.GetLessonRoundItemsUseCase
 import team.mozu.dsm.application.port.`in`.lesson.GetLessonRoundArticlesUseCase
+import team.mozu.dsm.application.port.`in`.lesson.GetLessonItemDetailUseCase
 import team.mozu.dsm.global.security.auth.StudentPrincipal
 import java.util.UUID
 
@@ -54,7 +56,8 @@ class LessonWebAdapter(
     private val nextLessonUseCase: NextLessonUseCase,
     private val lessonOrganSSEUseCase: LessonOrganSSEUseCase,
     private val getLessonRoundItemsUseCase: GetLessonRoundItemsUseCase,
-    private val getLessonRoundArticlesUseCase: GetLessonRoundArticlesUseCase
+    private val getLessonRoundArticlesUseCase: GetLessonRoundArticlesUseCase,
+    private val getLessonItemDetailUseCase: GetLessonItemDetailUseCase
 ) {
 
     @PostMapping
@@ -168,5 +171,14 @@ class LessonWebAdapter(
         @AuthenticationPrincipal studentPrincipal: StudentPrincipal
     ): List<LessonRoundArticleResponse> {
         return getLessonRoundArticlesUseCase.get(studentPrincipal.lessonNum)
+    }
+
+    @GetMapping("/team/item/{item-id}")
+    @ResponseStatus(HttpStatus.OK)
+    fun getLessonItemDetail(
+        @AuthenticationPrincipal studentPrincipal: StudentPrincipal,
+        @PathVariable("item-id") lessonId: UUID
+    ): LessonItemDetailResponse {
+        return getLessonItemDetailUseCase.get(studentPrincipal.lessonNum, lessonId)
     }
 }

--- a/src/main/kotlin/team/mozu/dsm/adapter/in/lesson/LessonWebAdapter.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/in/lesson/LessonWebAdapter.kt
@@ -148,7 +148,7 @@ class LessonWebAdapter(
     ) {
         nextLessonUseCase.next(lessonId)
     }
-    
+
     @GetMapping("/sse/{lesson-id}")
     @ResponseStatus(HttpStatus.OK)
     fun sse(

--- a/src/main/kotlin/team/mozu/dsm/adapter/in/lesson/dto/response/LessonItemDetailResponse.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/in/lesson/dto/response/LessonItemDetailResponse.kt
@@ -1,0 +1,21 @@
+package team.mozu.dsm.adapter.`in`.lesson.dto.response
+
+import java.util.UUID
+
+data class LessonItemDetailResponse(
+    val itemId: UUID,
+    val itemName: String,
+    val itemLogo: String?,
+    val nowMoney: Int,
+    val profitMoney: Int,
+    val profitNum: Double,
+    val moneyList: List<Int>,
+    val itemInfo: String,
+    val money: Int,
+    val debt: Int,
+    val capital: Int,
+    val profit: Int,
+    val profitOg: Int,
+    val profitBen: Int,
+    val netProfit: Int
+)

--- a/src/main/kotlin/team/mozu/dsm/adapter/in/lesson/dto/response/LessonRoundArticleResponse.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/in/lesson/dto/response/LessonRoundArticleResponse.kt
@@ -7,5 +7,5 @@ data class LessonRoundArticleResponse @QueryProjection constructor(
     val articleId: UUID,
     val title: String,
     val description: String,
-    val image: String?,
+    val image: String?
 )

--- a/src/main/kotlin/team/mozu/dsm/adapter/out/lesson/persistence/LessonItemPersistenceAdapter.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/out/lesson/persistence/LessonItemPersistenceAdapter.kt
@@ -1,6 +1,7 @@
 package team.mozu.dsm.adapter.out.lesson.persistence
 
 import com.querydsl.core.types.dsl.CaseBuilder
+import com.querydsl.core.types.dsl.NumberExpression
 import com.querydsl.jpa.impl.JPAQueryFactory
 import org.springframework.stereotype.Component
 import team.mozu.dsm.adapter.out.item.entity.QItemJpaEntity.itemJpaEntity
@@ -12,12 +13,14 @@ import team.mozu.dsm.adapter.out.lesson.persistence.repository.LessonItemReposit
 import team.mozu.dsm.adapter.out.lesson.persistence.repository.LessonRepository
 import team.mozu.dsm.application.exception.item.ItemNotFoundException
 import team.mozu.dsm.application.exception.lesson.LessonNotFoundException
-import team.mozu.dsm.application.port.`in`.lesson.command.LessonRoundItemCommand
-import team.mozu.dsm.application.port.`in`.lesson.command.QLessonRoundItemCommand
+import team.mozu.dsm.application.port.out.lesson.dto.LessonItemDetailProjection
 import team.mozu.dsm.application.port.out.lesson.CommandLessonItemPort
 import team.mozu.dsm.application.port.out.lesson.QueryLessonItemPort
+import team.mozu.dsm.application.port.out.lesson.dto.LessonRoundItemProjection
+import team.mozu.dsm.application.port.out.lesson.dto.QLessonItemDetailProjection
+import team.mozu.dsm.application.port.out.lesson.dto.QLessonRoundItemProjection
 import team.mozu.dsm.domain.lesson.model.LessonItem
-import java.util.*
+import java.util.UUID
 
 @Component
 class LessonItemPersistenceAdapter(
@@ -26,7 +29,7 @@ class LessonItemPersistenceAdapter(
     private val lessonItemMapper: LessonItemMapper,
     private val itemRepository: ItemRepository,
     private val jpaQueryFactory: JPAQueryFactory
-) : CommandLessonItemPort, QueryLessonItemPort {
+) : QueryLessonItemPort, CommandLessonItemPort {
 
     //--Query--//
     override fun findItemIdsByLessonId(lessonId: UUID): List<UUID> {
@@ -55,31 +58,15 @@ class LessonItemPersistenceAdapter(
             .map { lessonItemMapper.toModel(it) }
     }
 
-    override fun findAllRoundItemsByLessonId(lessonId: UUID): List<LessonRoundItemCommand> {
+    override fun findAllRoundItemsByLessonId(lessonId: UUID): List<LessonRoundItemProjection> {
         return jpaQueryFactory
             .select(
-                QLessonRoundItemCommand(
+                QLessonRoundItemProjection(
                     itemJpaEntity.id,
                     itemJpaEntity.itemName,
                     itemJpaEntity.itemLogo,
-                    // 이전 차수 금액 조회
-                    CaseBuilder()
-                        .`when`(lessonJpaEntity.curInvRound.eq(0)).then(0)
-                        .`when`(lessonJpaEntity.curInvRound.eq(1)).then(lessonItemJpaEntity.currentMoney)
-                        .`when`(lessonJpaEntity.curInvRound.eq(2)).then(lessonItemJpaEntity.round1Money)
-                        .`when`(lessonJpaEntity.curInvRound.eq(3)).then(lessonItemJpaEntity.round2Money)
-                        .`when`(lessonJpaEntity.curInvRound.eq(4)).then(lessonItemJpaEntity.round3Money)
-                        .`when`(lessonJpaEntity.curInvRound.eq(5)).then(lessonItemJpaEntity.round4Money.coalesce(0))
-                        .otherwise(0),
-                    // 현재 차수 값 조회
-                    CaseBuilder()
-                        .`when`(lessonJpaEntity.curInvRound.eq(0)).then(lessonItemJpaEntity.currentMoney)
-                        .`when`(lessonJpaEntity.curInvRound.eq(1)).then(lessonItemJpaEntity.round1Money)
-                        .`when`(lessonJpaEntity.curInvRound.eq(2)).then(lessonItemJpaEntity.round2Money)
-                        .`when`(lessonJpaEntity.curInvRound.eq(3)).then(lessonItemJpaEntity.round3Money)
-                        .`when`(lessonJpaEntity.curInvRound.eq(4)).then(lessonItemJpaEntity.round4Money)
-                        .`when`(lessonJpaEntity.curInvRound.eq(5)).then(lessonItemJpaEntity.round5Money.coalesce(0))
-                        .otherwise(0)
+                    getPreMoneyCase(),
+                    getCurMoneyCase()
                 )
             )
             .from(lessonItemJpaEntity)
@@ -90,6 +77,30 @@ class LessonItemPersistenceAdapter(
                     .and(lessonItemJpaEntity.lesson.isInProgress.isTrue)
             )
             .fetch()
+    }
+
+    override fun findItemDetailByLessonIdAndItemId(lessonId: UUID, itemId: UUID): LessonItemDetailProjection {
+        return jpaQueryFactory
+            .select(
+                QLessonItemDetailProjection(
+                    getPreMoneyCase(),
+                    getCurMoneyCase(),
+                    lessonItemJpaEntity.currentMoney,
+                    lessonItemJpaEntity.round1Money,
+                    lessonItemJpaEntity.round2Money,
+                    lessonItemJpaEntity.round3Money,
+                    lessonItemJpaEntity.round4Money,
+                    lessonItemJpaEntity.round5Money
+                )
+            )
+            .from(lessonItemJpaEntity)
+            .join(lessonItemJpaEntity.lesson, lessonJpaEntity)
+            .where(
+                lessonItemJpaEntity.lesson.id.eq(lessonId)
+                    .and(lessonItemJpaEntity.item.id.eq(itemId))
+                    .and(lessonJpaEntity.isInProgress.isTrue)
+            )
+            .fetchOne() ?: throw ItemNotFoundException
     }
 
     //--Command--//
@@ -125,5 +136,26 @@ class LessonItemPersistenceAdapter(
             .delete(lessonItemJpaEntity)
             .where(lessonItemJpaEntity.lesson.id.eq(lessonId))
             .execute()
+    }
+
+    //--CaseBuilder--//
+    private fun getPreMoneyCase(): NumberExpression<Int> {
+        return CaseBuilder()
+            .`when`(lessonJpaEntity.curInvRound.eq(1)).then(0)
+            .`when`(lessonJpaEntity.curInvRound.eq(2)).then(lessonItemJpaEntity.currentMoney)
+            .`when`(lessonJpaEntity.curInvRound.eq(3)).then(lessonItemJpaEntity.round1Money)
+            .`when`(lessonJpaEntity.curInvRound.eq(4)).then(lessonItemJpaEntity.round2Money)
+            .`when`(lessonJpaEntity.curInvRound.eq(5)).then(lessonItemJpaEntity.round3Money)
+            .otherwise(0)
+    }
+
+    private fun getCurMoneyCase(): NumberExpression<Int> {
+        return CaseBuilder()
+            .`when`(lessonJpaEntity.curInvRound.eq(1)).then(lessonItemJpaEntity.currentMoney)
+            .`when`(lessonJpaEntity.curInvRound.eq(2)).then(lessonItemJpaEntity.round1Money)
+            .`when`(lessonJpaEntity.curInvRound.eq(3)).then(lessonItemJpaEntity.round2Money)
+            .`when`(lessonJpaEntity.curInvRound.eq(4)).then(lessonItemJpaEntity.round3Money)
+            .`when`(lessonJpaEntity.curInvRound.eq(5)).then(lessonItemJpaEntity.round4Money.coalesce(0))
+            .otherwise(0)
     }
 }

--- a/src/main/kotlin/team/mozu/dsm/adapter/out/lesson/persistence/LessonItemPersistenceAdapter.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/out/lesson/persistence/LessonItemPersistenceAdapter.kt
@@ -12,6 +12,7 @@ import team.mozu.dsm.adapter.out.lesson.persistence.mapper.LessonItemMapper
 import team.mozu.dsm.adapter.out.lesson.persistence.repository.LessonItemRepository
 import team.mozu.dsm.adapter.out.lesson.persistence.repository.LessonRepository
 import team.mozu.dsm.application.exception.item.ItemNotFoundException
+import team.mozu.dsm.application.exception.lesson.LessonItemNotFoundException
 import team.mozu.dsm.application.exception.lesson.LessonNotFoundException
 import team.mozu.dsm.application.port.out.lesson.dto.LessonItemDetailProjection
 import team.mozu.dsm.application.port.out.lesson.CommandLessonItemPort
@@ -100,7 +101,7 @@ class LessonItemPersistenceAdapter(
                     .and(lessonItemJpaEntity.item.id.eq(itemId))
                     .and(lessonJpaEntity.isInProgress.isTrue)
             )
-            .fetchOne() ?: throw ItemNotFoundException
+            .fetchOne() ?: throw LessonItemNotFoundException
     }
 
     //--Command--//

--- a/src/main/kotlin/team/mozu/dsm/adapter/out/lesson/persistence/LessonPersistenceAdapter.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/out/lesson/persistence/LessonPersistenceAdapter.kt
@@ -73,6 +73,7 @@ class LessonPersistenceAdapter(
             .update(lessonJpaEntity)
             .set(lessonJpaEntity.lessonNum, lessonNum)
             .set(lessonJpaEntity.isInProgress, true)
+            .set(lessonJpaEntity.curInvRound, 1)
             .where(lessonJpaEntity.id.eq(id))
             .execute()
     }

--- a/src/main/kotlin/team/mozu/dsm/application/port/in/lesson/GetLessonItemDetailUseCase.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/port/in/lesson/GetLessonItemDetailUseCase.kt
@@ -1,0 +1,9 @@
+package team.mozu.dsm.application.port.`in`.lesson
+
+import team.mozu.dsm.adapter.`in`.lesson.dto.response.LessonItemDetailResponse
+import java.util.UUID
+
+interface GetLessonItemDetailUseCase {
+
+    fun get(lessonNum: String, itemId: UUID): LessonItemDetailResponse
+}

--- a/src/main/kotlin/team/mozu/dsm/application/port/in/lesson/GetLessonRoundItemsUseCase.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/port/in/lesson/GetLessonRoundItemsUseCase.kt
@@ -1,7 +1,6 @@
 package team.mozu.dsm.application.port.`in`.lesson
 
 import team.mozu.dsm.adapter.`in`.lesson.dto.response.LessonRoundItemResponse
-import java.util.UUID
 
 interface GetLessonRoundItemsUseCase {
 

--- a/src/main/kotlin/team/mozu/dsm/application/port/out/lesson/QueryLessonItemPort.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/port/out/lesson/QueryLessonItemPort.kt
@@ -1,6 +1,7 @@
 package team.mozu.dsm.application.port.out.lesson
 
-import team.mozu.dsm.application.port.`in`.lesson.command.LessonRoundItemCommand
+import team.mozu.dsm.application.port.out.lesson.dto.LessonItemDetailProjection
+import team.mozu.dsm.application.port.out.lesson.dto.LessonRoundItemProjection
 import team.mozu.dsm.domain.lesson.model.LessonItem
 import java.util.*
 
@@ -12,5 +13,7 @@ interface QueryLessonItemPort {
 
     fun findAllByLessonId(lessonId: UUID): List<LessonItem>
 
-    fun findAllRoundItemsByLessonId(lessonId: UUID): List<LessonRoundItemCommand>
+    fun findAllRoundItemsByLessonId(lessonId: UUID): List<LessonRoundItemProjection>
+
+    fun findItemDetailByLessonIdAndItemId(lessonId: UUID, itemId: UUID): LessonItemDetailProjection
 }

--- a/src/main/kotlin/team/mozu/dsm/application/port/out/lesson/dto/LessonItemDetailProjection.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/port/out/lesson/dto/LessonItemDetailProjection.kt
@@ -1,0 +1,14 @@
+package team.mozu.dsm.application.port.out.lesson.dto
+
+import com.querydsl.core.annotations.QueryProjection
+
+data class LessonItemDetailProjection @QueryProjection constructor(
+    val preMoney: Int,
+    val curMoney: Int,
+    val itemCurrentMoney: Int,
+    val itemRound1Money: Int,
+    val itemRound2Money: Int,
+    val itemRound3Money: Int,
+    val itemRound4Money: Int?,
+    val itemRound5Money: Int?
+)

--- a/src/main/kotlin/team/mozu/dsm/application/port/out/lesson/dto/LessonRoundItemProjection.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/port/out/lesson/dto/LessonRoundItemProjection.kt
@@ -1,9 +1,9 @@
-package team.mozu.dsm.application.port.`in`.lesson.command
+package team.mozu.dsm.application.port.out.lesson.dto
 
 import com.querydsl.core.annotations.QueryProjection
-import java.util.UUID
+import java.util.*
 
-data class LessonRoundItemCommand @QueryProjection constructor(
+data class LessonRoundItemProjection @QueryProjection constructor(
     val itemId: UUID,
     val itemName: String,
     val itemLogo: String?,

--- a/src/main/kotlin/team/mozu/dsm/application/service/lesson/GetLessonItemDetailService.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/service/lesson/GetLessonItemDetailService.kt
@@ -17,7 +17,7 @@ class GetLessonItemDetailService(
     private val lessonPort: QueryLessonPort,
     private val itemPort: QueryItemPort,
     private val lessonItemPort: QueryLessonItemPort
-): GetLessonItemDetailUseCase {
+) : GetLessonItemDetailUseCase {
 
     @Transactional(readOnly = true)
     override fun get(lessonNum: String, itemId: UUID): LessonItemDetailResponse {
@@ -33,7 +33,7 @@ class GetLessonItemDetailService(
             lessonItem.itemRound2Money,
             lessonItem.itemRound3Money,
             lessonItem.itemRound4Money ?: 0,
-            lessonItem.itemRound5Money ?: 0,
+            lessonItem.itemRound5Money ?: 0
         )
         val moneyList = itemMoneyList.take(lesson.curInvRound)
 

--- a/src/main/kotlin/team/mozu/dsm/application/service/lesson/GetLessonItemDetailService.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/service/lesson/GetLessonItemDetailService.kt
@@ -1,0 +1,69 @@
+package team.mozu.dsm.application.service.lesson
+
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import team.mozu.dsm.adapter.`in`.lesson.dto.response.LessonItemDetailResponse
+import team.mozu.dsm.application.exception.item.ItemNotFoundException
+import team.mozu.dsm.application.exception.lesson.LessonNotFoundException
+import team.mozu.dsm.application.port.`in`.lesson.GetLessonItemDetailUseCase
+import team.mozu.dsm.application.port.out.item.QueryItemPort
+import team.mozu.dsm.application.port.out.lesson.QueryLessonItemPort
+import team.mozu.dsm.application.port.out.lesson.QueryLessonPort
+import java.util.UUID
+import kotlin.math.roundToInt
+
+@Service
+class GetLessonItemDetailService(
+    private val lessonPort: QueryLessonPort,
+    private val itemPort: QueryItemPort,
+    private val lessonItemPort: QueryLessonItemPort
+): GetLessonItemDetailUseCase {
+
+    @Transactional(readOnly = true)
+    override fun get(lessonNum: String, itemId: UUID): LessonItemDetailResponse {
+        val lesson = lessonPort.findByLessonNum(lessonNum)
+            ?: throw LessonNotFoundException
+        val item = itemPort.findById(itemId)
+            ?: throw ItemNotFoundException
+        val lessonItem = lessonItemPort.findItemDetailByLessonIdAndItemId(lesson.id!!, item.id!!)
+
+        val itemMoneyList = listOf(
+            lessonItem.itemCurrentMoney,
+            lessonItem.itemRound1Money,
+            lessonItem.itemRound2Money,
+            lessonItem.itemRound3Money,
+            lessonItem.itemRound4Money ?: 0,
+            lessonItem.itemRound5Money ?: 0,
+        )
+        val moneyList = itemMoneyList.take(lesson.curInvRound)
+
+        val profitMoney = if (lessonItem.preMoney != 0) {
+            lessonItem.curMoney - lessonItem.preMoney
+        } else {
+            0
+        }
+        val profitNum = if (lessonItem.preMoney != 0) {
+            ((profitMoney.toDouble() * 100 / lessonItem.preMoney) * 100).roundToInt() / 100.0
+        } else {
+            0.0
+        }
+
+        return LessonItemDetailResponse(
+            itemId = item.id,
+            itemName = item.itemName,
+            itemLogo = item.itemLogo,
+            nowMoney = lessonItem.curMoney,
+            profitMoney = profitMoney,
+            profitNum = profitNum,
+            moneyList = moneyList,
+            itemInfo = item.itemInfo,
+            money = item.money,
+            debt = item.debt,
+            capital = item.capital,
+            profit = item.profit,
+            profitOg = item.profitOg,
+            profitBen = item.profitBenefit,
+            netProfit = item.netProfit
+        )
+    }
+}

--- a/src/main/kotlin/team/mozu/dsm/application/service/lesson/GetLessonRoundArticlesService.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/service/lesson/GetLessonRoundArticlesService.kt
@@ -12,7 +12,7 @@ import team.mozu.dsm.application.port.out.lesson.QueryLessonPort
 class GetLessonRoundArticlesService(
     private val lessonPort: QueryLessonPort,
     private val lessonArticlePort: QueryLessonArticlePort
-): GetLessonRoundArticlesUseCase {
+) : GetLessonRoundArticlesUseCase {
 
     @Transactional(readOnly = true)
     override fun get(lessonNum: String): List<LessonRoundArticleResponse> {

--- a/src/main/kotlin/team/mozu/dsm/application/service/lesson/LessonOrganSSEService.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/service/lesson/LessonOrganSSEService.kt
@@ -15,9 +15,9 @@ class LessonOrganSSEService(
     private val subscribeSsePort: SubscribeSsePort,
     private val lessonFacade: LessonFacade,
     private val securityPort: SecurityPort
-): LessonOrganSSEUseCase {
+) : LessonOrganSSEUseCase {
 
-    companion object{
+    companion object {
         private const val CONNECTED_EVENT = "LESSON_SSE_CONNECTED"
     }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

- #134 

## 📝작업 내용
- 수업 차수 종목 상세 조회 API 개발
- 중복되는 CaseBuilder 함수로 분리
- 수업 시작 시 curInvRound 1로 업데이트 로직 추가
- 기존 command 읽기 전용 dto인 projection으로 변경

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
<img width="1598" height="1274" alt="image" src="https://github.com/user-attachments/assets/d4a6cded-0da2-4501-9c80-debdd10ff62c" />


## 💬리뷰 요구사항(선택)
### 추후에 리팩토링을 할 예정이니 로직 상 오류가 없는지 위주로 봐주세요👐
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 아이템 상세 조회 API 추가: GET /team/item/{item-id}로 현재가, 수익금/수익률, 라운드별 금액 히스토리, 재무 지표, 로고/소개 등을 확인할 수 있습니다.
  - 라운드 기사 목록이 설명 대신 이미지(썸네일)를 표시하도록 변경되었습니다.

- 버그 수정
  - 수업 시작 시 현재 투자 라운드를 1로 초기화하여 진행 상태와 히스토리 표시가 올바르게 시작되도록 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->