### PR TITLE
Article update 수정

### DIFF
--- a/src/main/kotlin/team/mozu/dsm/adapter/out/article/persistence/ArticlePersistenceAdapter.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/out/article/persistence/ArticlePersistenceAdapter.kt
@@ -44,11 +44,9 @@ class ArticlePersistenceAdapter(
     override fun save(article: Article): Article {
         val organ = organRepository.findByIdOrNull(article.organId)
             ?: throw OrganNotFoundException
+        val saveArticle = articleRepository.save(articleMapper.toEntity(article, organ))
 
-        val entity = articleMapper.toEntity(article, organ)
-        val saved = articleRepository.save(entity)
-
-        return articleMapper.toModel(saved)
+        return articleMapper.toModel(saveArticle)
     }
 
     override fun delete(article: Article) {

--- a/src/main/kotlin/team/mozu/dsm/adapter/out/article/persistence/mapper/ArticleMapper.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/out/article/persistence/mapper/ArticleMapper.kt
@@ -28,6 +28,10 @@ abstract class ArticleMapper {
             articleDesc = model.articleDesc,
             articleImage = model.articleImage,
             isDeleted = model.isDeleted
-        )
+        ).apply {
+            this.id = model.id
+            this.createdAt = model.createdAt
+            this.updatedAt = model.updatedAt
+        }
     }
 }

--- a/src/main/kotlin/team/mozu/dsm/domain/article/model/Article.kt
+++ b/src/main/kotlin/team/mozu/dsm/domain/article/model/Article.kt
@@ -1,5 +1,6 @@
 package team.mozu.dsm.domain.article.model
 
+import team.mozu.dsm.adapter.`in`.article.dto.request.ArticleRequest
 import team.mozu.dsm.domain.annotation.Aggregate
 import java.time.LocalDateTime
 import java.util.UUID
@@ -14,4 +15,13 @@ data class Article(
     val isDeleted: Boolean,
     val createdAt: LocalDateTime,
     val updatedAt: LocalDateTime?
-)
+) {
+    fun updateArticle(request: ArticleRequest, articleImage: String?): Article {
+        return copy(
+            articleName = request.articleName,
+            articleDesc = request.articleDesc,
+            articleImage = articleImage,
+            updatedAt = LocalDateTime.now()
+        )
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈


## 📝작업 내용

> toEntity 메서드 로직을 수정하여 Article 모델의 기본 필드 외에도 id, createdAt, updatedAt 값이 ArticleJpaEntity로 매핑되도록 변경
> apply 블록을 활용해 가독성을 높이고 중복 코드를 줄임



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 금액 필드 전반을 64비트 정수로 확장하여 더 큰 금액을 안전하게 처리합니다.
- 리팩터링
  - 게시글 생성/수정 요청 형식을 단순화하여 단일 요청 객체로 처리합니다.
- 버그 수정
  - 금액 계산 시 오버플로우 가능성을 낮춰 안정성을 향상했습니다.
- 문서
  - 게시글 생성/수정 API 문서를 최신 요청 형식에 맞게 갱신했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->