### PR TITLE
Merge/178 query team ranks

### DIFF
--- a/src/main/kotlin/team/mozu/dsm/adapter/out/team/entity/TeamJpaEntity.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/out/team/entity/TeamJpaEntity.kt
@@ -28,7 +28,7 @@ class TeamJpaEntity(
     @Column(nullable = false)
     var valuationMoney: Long,
 
-    @Column(nullable = false, columnDefinition = "VARCHAR(40)")
+    @Column(nullable = false, columnDefinition = "CHAR(4)")
     var lessonNum: String,
 
     @Column(nullable = false)

--- a/src/main/kotlin/team/mozu/dsm/adapter/out/team/persistence/TeamPersistenceAdapter.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/out/team/persistence/TeamPersistenceAdapter.kt
@@ -72,13 +72,14 @@ class TeamPersistenceAdapter(
         return teams.map { teamMapper.toModel(it) }
     }
 
-    override fun existsByTeamNameAndLessonId(teamName: String, lessonId: UUID): Boolean {
+    override fun existsByTeamNameAndLessonIdAndLessonNum(teamName: String, lessonId: UUID, lessonNum: String): Boolean {
         return jpaQueryFactory
             .selectOne()
             .from(teamJpaEntity)
             .where(
                 teamJpaEntity.teamName.eq(teamName)
                     .and(teamJpaEntity.lesson.id.eq(lessonId))
+                    .and(teamJpaEntity.lessonNum.eq(lessonNum))
             )
             .fetchFirst() != null
     }

--- a/src/main/kotlin/team/mozu/dsm/adapter/out/team/persistence/TeamPersistenceAdapter.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/out/team/persistence/TeamPersistenceAdapter.kt
@@ -51,10 +51,10 @@ class TeamPersistenceAdapter(
         return entities.map { teamMapper.toModel(it) }
     }
 
-    override fun findAllByLessonId(lessonId: UUID): List<Team> {
+    override fun findAllByLessonNum(lessonNum: String): List<Team> {
         val teams = jpaQueryFactory
             .selectFrom(teamJpaEntity)
-            .where(teamJpaEntity.lesson.id.eq(lessonId))
+            .where(teamJpaEntity.lesson.lessonNum.eq(lessonNum))
             .fetch()
 
         return teams.map { teamMapper.toModel(it) }

--- a/src/main/kotlin/team/mozu/dsm/application/port/out/team/QueryTeamPort.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/port/out/team/QueryTeamPort.kt
@@ -11,7 +11,7 @@ interface QueryTeamPort {
 
     fun findAllByLessonNumOrderByTotalMoneyDesc(lessonNum: String): List<Team>
 
-    fun findAllByLessonId(lessonId: UUID): List<Team>
+    fun findAllByLessonNum(lessonNum: String): List<Team>
 
     fun findAllByLessonIdAndInvestmentInProgress(lessonId: UUID): List<Team>
 

--- a/src/main/kotlin/team/mozu/dsm/application/port/out/team/QueryTeamPort.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/port/out/team/QueryTeamPort.kt
@@ -15,5 +15,5 @@ interface QueryTeamPort {
 
     fun findAllByLessonIdAndInvestmentInProgress(lessonId: UUID): List<Team>
 
-    fun existsByTeamNameAndLessonId(teamName: String, lessonId: UUID): Boolean
+    fun existsByTeamNameAndLessonIdAndLessonNum(teamName: String, lessonId: UUID, lessonNum: String): Boolean
 }

--- a/src/main/kotlin/team/mozu/dsm/application/service/lesson/EndLessonService.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/service/lesson/EndLessonService.kt
@@ -36,7 +36,7 @@ class EndLessonService(
         }
 
         // 해당 수업에 참여 중인 팀들 조회
-        val teams = queryTeamPort.findAllByLessonId(lesson.id!!)
+        val teams = queryTeamPort.findAllByLessonNum(lesson.lessonNum!!)
 
         commandLessonPort.updateIsInProgress(lesson.id!!)
 

--- a/src/main/kotlin/team/mozu/dsm/application/service/lesson/NextLessonService.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/service/lesson/NextLessonService.kt
@@ -41,7 +41,7 @@ class NextLessonService(
         // 다음 차수 진행을 위해 curInvRound 업데이트
         val updatedLesson = lessonPort.updateCurInvRound(lesson.id!!)
         // 해당 수업에 참여중인 팀 조회
-        val teams = teamPort.findAllByLessonId(lesson.id)
+        val teams = teamPort.findAllByLessonNum(lesson.lessonNum!!)
 
         // 트랜잭션 커밋 후 이벤트 발행
         TransactionSynchronizationManager.registerSynchronization(

--- a/src/main/kotlin/team/mozu/dsm/application/service/lesson/StartLessonInvestmentService.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/service/lesson/StartLessonInvestmentService.kt
@@ -41,7 +41,7 @@ class StartLessonInvestmentService(
         // 수업 투자 시작을 위해 curInvRound 업데이트 (차수 증가)
         val updatedLesson = lessonPort.updateCurInvRound(lesson.id!!)
         // 해당 수업에 참여중인 팀 조회
-        val teams = teamPort.findAllByLessonId(lesson.id)
+        val teams = teamPort.findAllByLessonNum(lesson.lessonNum!!)
 
         // 트랜잭션 커밋 후 이벤트 발행
         TransactionSynchronizationManager.registerSynchronization(

--- a/src/main/kotlin/team/mozu/dsm/application/service/lesson/StartLessonService.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/service/lesson/StartLessonService.kt
@@ -52,7 +52,7 @@ class StartLessonService(
                 val updatedLesson = lessonFacade.findByLessonId(lesson.id)
 
                 // 해당 수업에 참여중인 팀 조회
-                val teams = teamPort.findAllByLessonId(lesson.id)
+                val teams = teamPort.findAllByLessonNum(lesson.lessonNum!!)
 
                 // 트랜잭션 커밋 후 이벤트 발행
                 TransactionSynchronizationManager.registerSynchronization(

--- a/src/main/kotlin/team/mozu/dsm/application/service/team/GetTeamRanksService.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/service/team/GetTeamRanksService.kt
@@ -3,7 +3,6 @@ package team.mozu.dsm.application.service.team
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import team.mozu.dsm.adapter.`in`.team.dto.response.TeamRankResponse
-import team.mozu.dsm.application.exception.lesson.LessonItemNotFoundException
 import team.mozu.dsm.application.exception.lesson.LessonNotFoundException
 import team.mozu.dsm.application.port.`in`.team.GetTeamRanksUseCase
 import team.mozu.dsm.application.port.out.lesson.QueryLessonItemPort
@@ -26,7 +25,7 @@ class GetTeamRanksService(
             ?: throw LessonNotFoundException
 
         // lessonNum으로 모든 팀 조회 (정렬 없이)
-        val allTeams = queryTeamPort.findAllByLessonId(lesson.id!!)
+        val allTeams = queryTeamPort.findAllByLessonNum(lesson.lessonNum!!)
 
         // 수익 계산을 위한 차수: 현재 진행 차수(N) + 1 (/team/result와 동일)
         val profitCalculationRound = lesson.curInvRound + 1
@@ -37,7 +36,7 @@ class GetTeamRanksService(
             val stockItemIds = stocks.map { it.itemId }.distinct()
 
             val lessonItemMap = if (stockItemIds.isNotEmpty()) {
-                queryLessonItemPort.findAllByLessonIdAndItemIds(lesson.id, stockItemIds)
+                queryLessonItemPort.findAllByLessonIdAndItemIds(lesson.id!!, stockItemIds)
                     .associateBy { it.lessonItemId.itemId }
             } else {
                 emptyMap()

--- a/src/main/kotlin/team/mozu/dsm/application/service/team/TeamParticipationService.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/service/team/TeamParticipationService.kt
@@ -42,7 +42,7 @@ class TeamParticipationService(
             ?: throw OrganNotFoundException
 
         lesson.id?.let { lessonId ->
-            if (queryTeamPort.existsByTeamNameAndLessonId(request.teamName, lessonId)) {
+            if (queryTeamPort.existsByTeamNameAndLessonIdAndLessonNum(request.teamName, lessonId, request.lessonNum)) {
                 throw TeamAlreadyExistsException
             }
         } ?: throw LessonNotFoundException

--- a/src/main/resources/db/migration/V8__modify_tbl_team.sql
+++ b/src/main/resources/db/migration/V8__modify_tbl_team.sql
@@ -1,0 +1,7 @@
+ALTER TABLE tbl_team MODIFY COLUMN lesson_num CHAR(4) NOT NULL;
+
+ALTER TABLE tbl_team DROP INDEX uq_team_name_lesson_id;
+
+ALTER TABLE tbl_team
+    ADD CONSTRAINT uq_team_name_lesson_num_lesson_id
+        UNIQUE (team_name, lesson_num, lesson_id);


### PR DESCRIPTION
## #️⃣연관된 이슈

- #178 

## 📝작업 내용
- 랭킹 조회 시 이전에 참여했던 팀까지 조회되던 문제 수정
  - 매 수업마다 생성되는 lessonNum을 기준으로 현재 참여 중인 팀만 조회하도록 변경
- lessonNum 컬럼 크기 변경 (varchar(40) → char(4))
- 한 수업 내에서 팀 이름 중복 방지를 위해 unique 제약 조건에 lessonNum 추가
  - 수업 참여 시 팀 존재 여부를 lessonNum 기준으로 함께 검증

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

