### PR TITLE
Merge/181 lesson participation and rank query

### DIFF
--- a/src/main/kotlin/team/mozu/dsm/adapter/in/lesson/dto/StartLessonEventDTO.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/in/lesson/dto/StartLessonEventDTO.kt
@@ -1,0 +1,11 @@
+package team.mozu.dsm.adapter.`in`.lesson.dto
+
+import java.util.UUID
+
+data class StartLessonEventDTO(
+    val lessonId: UUID,
+    val curInvRound: Int,
+    val teamId: UUID,
+    val teamName: String?,
+    val schoolName: String
+)

--- a/src/main/kotlin/team/mozu/dsm/adapter/out/team/persistence/TeamPersistenceAdapter.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/out/team/persistence/TeamPersistenceAdapter.kt
@@ -51,10 +51,13 @@ class TeamPersistenceAdapter(
         return entities.map { teamMapper.toModel(it) }
     }
 
-    override fun findAllByLessonNum(lessonNum: String): List<Team> {
+    override fun findAllByLessonId(lessonId: UUID): List<Team> {
         val teams = jpaQueryFactory
             .selectFrom(teamJpaEntity)
-            .where(teamJpaEntity.lesson.lessonNum.eq(lessonNum))
+            .where(
+                teamJpaEntity.lesson.id.eq(lessonId)
+                    .and(teamJpaEntity.isInvestmentInProgress.isTrue)
+            )
             .fetch()
 
         return teams.map { teamMapper.toModel(it) }

--- a/src/main/kotlin/team/mozu/dsm/adapter/out/team/persistence/TeamPersistenceAdapter.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/out/team/persistence/TeamPersistenceAdapter.kt
@@ -116,4 +116,16 @@ class TeamPersistenceAdapter(
         val savedEntity = teamRepository.save(entity)
         return teamMapper.toModel(savedEntity)
     }
+
+    override fun updateIsInvestmentInProgress(teams: List<Team>) {
+        if (teams.isEmpty()) return
+
+        val teamIds = teams.map { it.id }
+
+        jpaQueryFactory
+            .update(teamJpaEntity)
+            .set(teamJpaEntity.isInvestmentInProgress, false)
+            .where(teamJpaEntity.id.`in`(teamIds))
+            .execute()
+    }
 }

--- a/src/main/kotlin/team/mozu/dsm/application/exception/lesson/CannotParticipateLessonException.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/exception/lesson/CannotParticipateLessonException.kt
@@ -1,0 +1,6 @@
+package team.mozu.dsm.application.exception.lesson
+
+import team.mozu.dsm.global.error.exception.ErrorCode
+import team.mozu.dsm.global.error.exception.MozuException
+
+object CannotParticipateLessonException : MozuException(ErrorCode.CANNOT_PARTICIPATE_LESSON)

--- a/src/main/kotlin/team/mozu/dsm/application/exception/lesson/CannotStartInvestmentException.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/exception/lesson/CannotStartInvestmentException.kt
@@ -1,0 +1,6 @@
+package team.mozu.dsm.application.exception.lesson
+
+import team.mozu.dsm.global.error.exception.ErrorCode
+import team.mozu.dsm.global.error.exception.MozuException
+
+object CannotStartInvestmentException : MozuException(ErrorCode.CANNOT_START_INVESTMENT)

--- a/src/main/kotlin/team/mozu/dsm/application/port/out/team/CommandTeamPort.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/port/out/team/CommandTeamPort.kt
@@ -7,4 +7,6 @@ interface CommandTeamPort {
     fun save(team: Team): Team
 
     fun update(team: Team): Team
+
+    fun updateIsInvestmentInProgress(teams: List<Team>)
 }

--- a/src/main/kotlin/team/mozu/dsm/application/port/out/team/QueryTeamPort.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/port/out/team/QueryTeamPort.kt
@@ -11,7 +11,7 @@ interface QueryTeamPort {
 
     fun findAllByLessonNumOrderByTotalMoneyDesc(lessonNum: String): List<Team>
 
-    fun findAllByLessonNum(lessonNum: String): List<Team>
+    fun findAllByLessonId(lessonId: UUID): List<Team>
 
     fun findAllByLessonIdAndInvestmentInProgress(lessonId: UUID): List<Team>
 

--- a/src/main/kotlin/team/mozu/dsm/application/service/lesson/EndLessonService.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/service/lesson/EndLessonService.kt
@@ -9,6 +9,7 @@ import team.mozu.dsm.application.port.`in`.lesson.EndLessonUseCase
 import team.mozu.dsm.application.port.out.auth.SecurityPort
 import team.mozu.dsm.application.port.out.lesson.CommandLessonPort
 import team.mozu.dsm.application.port.out.sse.PublishSsePort
+import team.mozu.dsm.application.port.out.team.CommandTeamPort
 import team.mozu.dsm.application.port.out.team.QueryTeamPort
 import team.mozu.dsm.application.service.lesson.facade.LessonFacade
 import java.util.UUID
@@ -19,7 +20,8 @@ class EndLessonService(
     private val commandLessonPort: CommandLessonPort,
     private val securityPort: SecurityPort,
     private val publishSsePort: PublishSsePort,
-    private val queryTeamPort: QueryTeamPort
+    private val queryTeamPort: QueryTeamPort,
+    private val commandTeamPort: CommandTeamPort
 ) : EndLessonUseCase {
 
     companion object {
@@ -39,6 +41,7 @@ class EndLessonService(
         val teams = queryTeamPort.findAllByLessonId(lesson.id!!)
 
         commandLessonPort.updateIsInProgress(lesson.id)
+        commandTeamPort.updateIsInvestmentInProgress(teams)
 
         // 트랜잭션 커밋 후 팀들에게 수업 취소 이벤트 발행
         TransactionSynchronizationManager.registerSynchronization(

--- a/src/main/kotlin/team/mozu/dsm/application/service/lesson/EndLessonService.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/service/lesson/EndLessonService.kt
@@ -36,9 +36,9 @@ class EndLessonService(
         }
 
         // 해당 수업에 참여 중인 팀들 조회
-        val teams = queryTeamPort.findAllByLessonNum(lesson.lessonNum!!)
+        val teams = queryTeamPort.findAllByLessonId(lesson.id!!)
 
-        commandLessonPort.updateIsInProgress(lesson.id!!)
+        commandLessonPort.updateIsInProgress(lesson.id)
 
         // 트랜잭션 커밋 후 팀들에게 수업 취소 이벤트 발행
         TransactionSynchronizationManager.registerSynchronization(

--- a/src/main/kotlin/team/mozu/dsm/application/service/lesson/NextLessonService.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/service/lesson/NextLessonService.kt
@@ -2,32 +2,21 @@ package team.mozu.dsm.application.service.lesson
 
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import org.springframework.transaction.support.TransactionSynchronization
-import org.springframework.transaction.support.TransactionSynchronizationManager
-import team.mozu.dsm.adapter.`in`.lesson.dto.NextLessonEventDTO
 import team.mozu.dsm.application.exception.lesson.CannotNextLessonException
+import team.mozu.dsm.application.exception.lesson.LessonNotInProgressException
 import team.mozu.dsm.application.port.`in`.lesson.NextLessonUseCase
 import team.mozu.dsm.application.port.out.auth.SecurityPort
-import team.mozu.dsm.application.port.out.lesson.CommandLessonPort
-import team.mozu.dsm.application.port.out.sse.PublishSsePort
-import team.mozu.dsm.application.port.out.team.QueryTeamPort
 import team.mozu.dsm.application.service.lesson.facade.LessonFacade
+import team.mozu.dsm.application.service.team.facade.TeamFacade
+import team.mozu.dsm.domain.sse.model.SseEventType
 import java.util.UUID
 
 @Service
 class NextLessonService(
     private val lessonFacade: LessonFacade,
-    private val lessonPort: CommandLessonPort,
-    private val publishSsePort: PublishSsePort,
-    private val teamPort: QueryTeamPort,
+    private val teamFacade: TeamFacade,
     private val securityPort: SecurityPort
 ) : NextLessonUseCase {
-
-    companion object {
-        private const val NEXT_LESSON_EVENT = "CLASS_NEXT_INV_START"
-    }
-
-    private val log = org.slf4j.LoggerFactory.getLogger(javaClass)
 
     @Transactional
     override fun next(lessonId: UUID) {
@@ -38,32 +27,10 @@ class NextLessonService(
             throw CannotNextLessonException
         }
 
-        // 다음 차수 진행을 위해 curInvRound 업데이트
-        val updatedLesson = lessonPort.updateCurInvRound(lesson.id!!)
-        // 해당 수업에 참여중인 팀 조회
-        val teams = teamPort.findAllByLessonId(lesson.id)
+        if (!lesson.isInProgress) {
+            throw LessonNotInProgressException
+        }
 
-        // 트랜잭션 커밋 후 이벤트 발행
-        TransactionSynchronizationManager.registerSynchronization(
-            object : TransactionSynchronization {
-                override fun afterCommit() {
-                    teams.forEach { team ->
-                        try {
-                            val eventData = NextLessonEventDTO(
-                                lessonId = updatedLesson.id!!,
-                                curInvRound = updatedLesson.curInvRound,
-                                teamId = team.id!!,
-                                teamName = team.teamName,
-                                schoolName = team.schoolName
-                            )
-                            publishSsePort.publishTo("team-sse:${team.id}", NEXT_LESSON_EVENT, eventData)
-                        } catch (e: Exception) {
-                            // 개별 팀 이벤트 전송 실패가 다른 팀에 영향을 주지 않도록 예외 처리
-                            log.error("Failed to send CLASS_NEXT_INV_START event to team ${team.id}", e)
-                        }
-                    }
-                }
-            }
-        )
+        teamFacade.updateCurRoundAndPublishEvent(lessonId, SseEventType.NEXT_LESSON_EVENT)
     }
 }

--- a/src/main/kotlin/team/mozu/dsm/application/service/lesson/NextLessonService.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/service/lesson/NextLessonService.kt
@@ -41,7 +41,7 @@ class NextLessonService(
         // 다음 차수 진행을 위해 curInvRound 업데이트
         val updatedLesson = lessonPort.updateCurInvRound(lesson.id!!)
         // 해당 수업에 참여중인 팀 조회
-        val teams = teamPort.findAllByLessonNum(lesson.lessonNum!!)
+        val teams = teamPort.findAllByLessonId(lesson.id)
 
         // 트랜잭션 커밋 후 이벤트 발행
         TransactionSynchronizationManager.registerSynchronization(

--- a/src/main/kotlin/team/mozu/dsm/application/service/lesson/StartLessonInvestmentService.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/service/lesson/StartLessonInvestmentService.kt
@@ -41,7 +41,7 @@ class StartLessonInvestmentService(
         // 수업 투자 시작을 위해 curInvRound 업데이트 (차수 증가)
         val updatedLesson = lessonPort.updateCurInvRound(lesson.id!!)
         // 해당 수업에 참여중인 팀 조회
-        val teams = teamPort.findAllByLessonNum(lesson.lessonNum!!)
+        val teams = teamPort.findAllByLessonId(lesson.id)
 
         // 트랜잭션 커밋 후 이벤트 발행
         TransactionSynchronizationManager.registerSynchronization(

--- a/src/main/kotlin/team/mozu/dsm/application/service/lesson/StartLessonInvestmentService.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/service/lesson/StartLessonInvestmentService.kt
@@ -2,32 +2,20 @@ package team.mozu.dsm.application.service.lesson
 
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import org.springframework.transaction.support.TransactionSynchronization
-import org.springframework.transaction.support.TransactionSynchronizationManager
-import team.mozu.dsm.adapter.`in`.lesson.dto.NextLessonEventDTO
-import team.mozu.dsm.application.exception.lesson.CannotNextLessonException
+import team.mozu.dsm.application.exception.lesson.CannotStartLessonException
 import team.mozu.dsm.application.port.`in`.lesson.StartLessonInvestmentUseCase
 import team.mozu.dsm.application.port.out.auth.SecurityPort
-import team.mozu.dsm.application.port.out.lesson.CommandLessonPort
-import team.mozu.dsm.application.port.out.sse.PublishSsePort
-import team.mozu.dsm.application.port.out.team.QueryTeamPort
 import team.mozu.dsm.application.service.lesson.facade.LessonFacade
+import team.mozu.dsm.application.service.team.facade.TeamFacade
+import team.mozu.dsm.domain.sse.model.SseEventType
 import java.util.UUID
 
 @Service
 class StartLessonInvestmentService(
     private val lessonFacade: LessonFacade,
-    private val lessonPort: CommandLessonPort,
-    private val publishSsePort: PublishSsePort,
-    private val teamPort: QueryTeamPort,
+    private val teamFacade: TeamFacade,
     private val securityPort: SecurityPort
 ) : StartLessonInvestmentUseCase {
-
-    companion object {
-        private const val START_LESSON_EVENT = "CLASS_START"
-    }
-
-    private val log = org.slf4j.LoggerFactory.getLogger(javaClass)
 
     @Transactional
     override fun startInvestment(lessonId: UUID) {
@@ -35,35 +23,9 @@ class StartLessonInvestmentService(
         val lesson = lessonFacade.findByLessonId(lessonId)
 
         if (lesson.organId != organ.id) {
-            throw CannotNextLessonException
+            throw CannotStartLessonException
         }
 
-        // 수업 투자 시작을 위해 curInvRound 업데이트 (차수 증가)
-        val updatedLesson = lessonPort.updateCurInvRound(lesson.id!!)
-        // 해당 수업에 참여중인 팀 조회
-        val teams = teamPort.findAllByLessonId(lesson.id)
-
-        // 트랜잭션 커밋 후 이벤트 발행
-        TransactionSynchronizationManager.registerSynchronization(
-            object : TransactionSynchronization {
-                override fun afterCommit() {
-                    teams.forEach { team ->
-                        try {
-                            val eventData = NextLessonEventDTO(
-                                lessonId = updatedLesson.id!!,
-                                curInvRound = updatedLesson.curInvRound,
-                                teamId = team.id!!,
-                                teamName = team.teamName,
-                                schoolName = team.schoolName
-                            )
-                            publishSsePort.publishTo("team-sse:${team.id}", START_LESSON_EVENT, eventData)
-                        } catch (e: Exception) {
-                            // 개별 팀 이벤트 전송 실패가 다른 팀에 영향을 주지 않도록 예외 처리
-                            log.error("Failed to send CLASS_START event to team ${team.id}", e)
-                        }
-                    }
-                }
-            }
-        )
+        teamFacade.updateCurRoundAndPublishEvent(lesson.id!!, SseEventType.START_LESSON_EVENT)
     }
 }

--- a/src/main/kotlin/team/mozu/dsm/application/service/lesson/StartLessonService.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/service/lesson/StartLessonService.kt
@@ -3,16 +3,11 @@ package team.mozu.dsm.application.service.lesson
 import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import org.springframework.transaction.support.TransactionSynchronization
-import org.springframework.transaction.support.TransactionSynchronizationManager
-import team.mozu.dsm.adapter.`in`.lesson.dto.NextLessonEventDTO
 import team.mozu.dsm.adapter.`in`.lesson.dto.response.StartLessonResponse
 import team.mozu.dsm.application.exception.lesson.CannotStartLessonException
 import team.mozu.dsm.application.port.`in`.lesson.StartLessonUseCase
 import team.mozu.dsm.application.port.out.auth.SecurityPort
 import team.mozu.dsm.application.port.out.lesson.CommandLessonPort
-import team.mozu.dsm.application.port.out.sse.PublishSsePort
-import team.mozu.dsm.application.port.out.team.QueryTeamPort
 import team.mozu.dsm.application.service.lesson.facade.LessonFacade
 import java.security.SecureRandom
 import java.util.UUID
@@ -21,17 +16,12 @@ import java.util.UUID
 class StartLessonService(
     private val lessonFacade: LessonFacade,
     private val commandLessonPort: CommandLessonPort,
-    private val securityPort: SecurityPort,
-    private val publishSsePort: PublishSsePort,
-    private val teamPort: QueryTeamPort
+    private val securityPort: SecurityPort
 ) : StartLessonUseCase {
 
     companion object {
         val random: SecureRandom = SecureRandom()
-        private const val START_LESSON_EVENT = "CLASS_START"
     }
-
-    private val log = org.slf4j.LoggerFactory.getLogger(javaClass)
 
     @Transactional
     override fun start(id: UUID): StartLessonResponse {
@@ -49,34 +39,6 @@ class StartLessonService(
             lessonNum = createCode()
             try {
                 commandLessonPort.updateLessonNumAndIsInProgress(lesson.id!!, lessonNum)
-                val updatedLesson = lessonFacade.findByLessonId(lesson.id)
-
-                // 해당 수업에 참여중인 팀 조회
-                val teams = teamPort.findAllByLessonNum(lesson.lessonNum!!)
-
-                // 트랜잭션 커밋 후 이벤트 발행
-                TransactionSynchronizationManager.registerSynchronization(
-                    object : TransactionSynchronization {
-                        override fun afterCommit() {
-                            teams.forEach { team ->
-                                try {
-                                    val eventData = NextLessonEventDTO(
-                                        lessonId = updatedLesson.id!!,
-                                        curInvRound = updatedLesson.curInvRound,
-                                        teamId = team.id!!,
-                                        teamName = team.teamName,
-                                        schoolName = team.schoolName
-                                    )
-                                    publishSsePort.publishTo("team-sse:${team.id}", START_LESSON_EVENT, eventData)
-                                } catch (e: Exception) {
-                                    // 개별 팀 이벤트 전송 실패가 다른 팀에 영향을 주지 않도록 예외 처리
-                                    log.error("Failed to send CLASS_START event to team ${team.id}", e)
-                                }
-                            }
-                        }
-                    }
-                )
-
                 break // 성공하면 루프 종료
             } catch (e: DataIntegrityViolationException) {
                 // 유니크 충돌 시 재시도

--- a/src/main/kotlin/team/mozu/dsm/application/service/team/GetTeamRanksService.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/service/team/GetTeamRanksService.kt
@@ -24,13 +24,13 @@ class GetTeamRanksService(
         val lesson = queryLessonPort.findByLessonNum(lessonNum)
             ?: throw LessonNotFoundException
 
-        // lessonNum으로 모든 팀 조회 (정렬 없이)
-        val allTeams = queryTeamPort.findAllByLessonNum(lesson.lessonNum!!)
+        // 수업에 참여중인 모든 팀 조회
+        val teams = queryTeamPort.findAllByLessonId(lesson.id!!)
 
         // 수익 계산을 위한 차수: 현재 진행 차수(N) + 1 (/team/result와 동일)
         val profitCalculationRound = lesson.curInvRound + 1
 
-        val teamRanks = allTeams.map { team ->
+        val teamRanks = teams.map { team ->
             // 각 팀의 주식 조회
             val stocks = queryStockPort.findAllByTeamId(team.id!!)
             val stockItemIds = stocks.map { it.itemId }.distinct()

--- a/src/main/kotlin/team/mozu/dsm/application/service/team/TeamParticipationService.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/service/team/TeamParticipationService.kt
@@ -36,7 +36,7 @@ class TeamParticipationService(
     @Transactional
     override fun participate(request: TeamParticipationRequest): TeamTokenResponse {
         val lesson = queryLessonPort.findByLessonNum(request.lessonNum)
-            ?: throw LessonNumNotFoundException
+            ?: throw LessonNotFoundException
 
         val organ = queryOrganPort.findModelById(lesson.organId)
             ?: throw OrganNotFoundException

--- a/src/main/kotlin/team/mozu/dsm/application/service/team/TeamParticipationService.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/service/team/TeamParticipationService.kt
@@ -7,9 +7,10 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
 import team.mozu.dsm.adapter.`in`.team.dto.TeamParticipationEventDTO
 import team.mozu.dsm.adapter.`in`.team.dto.request.TeamParticipationRequest
 import team.mozu.dsm.adapter.`in`.team.dto.response.TeamTokenResponse
-import team.mozu.dsm.application.exception.lesson.LessonDeletedException
 import team.mozu.dsm.application.exception.lesson.LessonNotFoundException
 import team.mozu.dsm.application.exception.lesson.LessonNotInProgressException
+import team.mozu.dsm.application.exception.lesson.CannotParticipateLessonException
+import team.mozu.dsm.application.exception.lesson.LessonDeletedException
 import team.mozu.dsm.application.exception.lesson.LessonNumNotFoundException
 import team.mozu.dsm.application.exception.organ.OrganNotFoundException
 import team.mozu.dsm.application.exception.team.TeamAlreadyExistsException
@@ -49,6 +50,10 @@ class TeamParticipationService(
 
         if (!lesson.isInProgress) {
             throw LessonNotInProgressException
+        }
+
+        if (lesson.curInvRound > 0) {
+            throw CannotParticipateLessonException
         }
 
         if (lesson.isDeleted) {

--- a/src/main/kotlin/team/mozu/dsm/application/service/team/facade/TeamFacade.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/service/team/facade/TeamFacade.kt
@@ -1,0 +1,51 @@
+package team.mozu.dsm.application.service.team.facade
+
+import org.springframework.stereotype.Component
+import org.springframework.transaction.support.TransactionSynchronization
+import org.springframework.transaction.support.TransactionSynchronizationManager
+import team.mozu.dsm.adapter.`in`.lesson.dto.NextLessonEventDTO
+import team.mozu.dsm.application.port.out.lesson.CommandLessonPort
+import team.mozu.dsm.application.port.out.sse.PublishSsePort
+import team.mozu.dsm.application.port.out.team.QueryTeamPort
+import team.mozu.dsm.domain.sse.model.SseEventType
+import java.util.UUID
+
+@Component
+class TeamFacade(
+    private val commandLessonPort: CommandLessonPort,
+    private val publishSsePort: PublishSsePort,
+    private val teamPort: QueryTeamPort
+) {
+
+    private val log = org.slf4j.LoggerFactory.getLogger(javaClass)
+
+    fun updateCurRoundAndPublishEvent(lessonId: UUID, eventType: SseEventType) {
+        // 수업 시작 및 다음 차수 진행을 위해 curInvRound 업데이트
+        val updatedLesson = commandLessonPort.updateCurInvRound(lessonId)
+        // 해당 수업에 참여중인 팀 조회
+        val teams = teamPort.findAllByLessonId(lessonId)
+
+        // 트랜잭션 커밋 후 이벤트 발행
+        TransactionSynchronizationManager.registerSynchronization(
+            object : TransactionSynchronization {
+                override fun afterCommit() {
+                    teams.forEach { team ->
+                        try {
+                            val eventData = NextLessonEventDTO(
+                                lessonId = updatedLesson.id!!,
+                                curInvRound = updatedLesson.curInvRound,
+                                teamId = team.id!!,
+                                teamName = team.teamName,
+                                schoolName = team.schoolName
+                            )
+                            publishSsePort.publishTo("team-sse:${team.id}", eventType.eventName, eventData)
+                        } catch (e: Exception) {
+                            // 개별 팀 이벤트 전송 실패가 다른 팀에 영향을 주지 않도록 예외 처리
+                            log.error("Failed to send CLASS_NEXT_INV_START event to team ${team.id}", e)
+                        }
+                    }
+                }
+            }
+        )
+    }
+}

--- a/src/main/kotlin/team/mozu/dsm/domain/sse/model/SseEventType.kt
+++ b/src/main/kotlin/team/mozu/dsm/domain/sse/model/SseEventType.kt
@@ -1,0 +1,9 @@
+package team.mozu.dsm.domain.sse.model
+
+enum class SseEventType(
+    val eventName: String
+) {
+    // lesson
+    NEXT_LESSON_EVENT("CLASS_NEXT_INV_START"),
+    START_LESSON_EVENT("CLASS_START")
+}

--- a/src/main/kotlin/team/mozu/dsm/global/error/exception/ErrorCode.kt
+++ b/src/main/kotlin/team/mozu/dsm/global/error/exception/ErrorCode.kt
@@ -51,9 +51,11 @@ enum class ErrorCode(
     CANNOT_UPDATE_LESSON(HttpStatus.FORBIDDEN, "Can't Update Lesson"),
     CANNOT_DELETE_LESSON(HttpStatus.FORBIDDEN, "Can't Delete Lesson"),
     MAX_INVESTMENT_ROUND_REACHED(HttpStatus.CONFLICT, "Max Investment Round Reached"),
+    CANNOT_PARTICIPATE_LESSON(HttpStatus.FORBIDDEN, "Can't Participate Lesson"),
     CANNOT_STAR_LESSON(HttpStatus.FORBIDDEN, "Can't Star Lesson"),
     CANNOT_END_LESSON(HttpStatus.FORBIDDEN, "Can't End Lesson"),
     CANNOT_NEXT_LESSON(HttpStatus.FORBIDDEN, "Can't Next Lesson"),
+    CANNOT_START_INVESTMENT(HttpStatus.FORBIDDEN, "Can't Start Investment Lesson"),
     CANNOT_START_LESSON(HttpStatus.FORBIDDEN, "Can't Start Lesson"),
     CANNOT_LESSON_SSE_CONNECT(HttpStatus.FORBIDDEN, "Can't Lesson SSE Connect"),
 


### PR DESCRIPTION
## #️⃣연관된 이슈

- #181 

## 📝작업 내용

- 수업 참여 시 이미 시작한 수업일 경우 참여하지 못하도록 변경
<img width="1576" height="928" alt="image" src="https://github.com/user-attachments/assets/bb29a179-1315-4751-bc3c-0b7f54187508" />

- 랭킹 조회 시 현재 참여중인 팀만 조회되도록 변경
- 중복되는 NextLessonService, StartLessonInvestmentService -> teamFacade로 분리
- 적절한 예외처리 추가

추후 개선 사항
- 이벤트 발송 로직 분리
- SSE 이벤트 이넘으로 관리

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

