### PR TITLE
Merge/185 dto structure

### DIFF
--- a/src/main/kotlin/team/mozu/dsm/adapter/in/article/dto/response/ArticleDetailResponse.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/in/article/dto/response/ArticleDetailResponse.kt
@@ -1,6 +1,7 @@
 package team.mozu.dsm.adapter.`in`.article.dto.response
 
 import com.fasterxml.jackson.annotation.JsonFormat
+import team.mozu.dsm.domain.article.model.Article
 import java.time.LocalDateTime
 import java.util.UUID
 
@@ -12,4 +13,17 @@ data class ArticleDetailResponse(
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
     val createdAt: LocalDateTime,
     val isDeleted: Boolean
-)
+) {
+    companion object {
+        fun from(article: Article): ArticleDetailResponse {
+            return ArticleDetailResponse(
+                id = article.id!!,
+                articleName = article.articleName,
+                articleDesc = article.articleDesc,
+                articleImg = article.articleImage,
+                createdAt = article.createdAt,
+                isDeleted = article.isDeleted
+            )
+        }
+    }
+}

--- a/src/main/kotlin/team/mozu/dsm/adapter/in/article/dto/response/ArticleResponse.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/in/article/dto/response/ArticleResponse.kt
@@ -1,5 +1,6 @@
 package team.mozu.dsm.adapter.`in`.article.dto.response
 
+import team.mozu.dsm.domain.article.model.Article
 import java.time.LocalDateTime
 import java.util.UUID
 
@@ -7,4 +8,14 @@ data class ArticleResponse(
     val id: UUID,
     val articleName: String,
     val createdAt: LocalDateTime
-)
+) {
+    companion object {
+        fun from(article: Article): ArticleResponse {
+            return ArticleResponse(
+                id = article.id!!,
+                articleName = article.articleName,
+                createdAt = article.createdAt
+            )
+        }
+    }
+}

--- a/src/main/kotlin/team/mozu/dsm/adapter/in/item/dto/response/ItemDetailResponse.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/in/item/dto/response/ItemDetailResponse.kt
@@ -1,6 +1,7 @@
 package team.mozu.dsm.adapter.`in`.item.dto.response
 
 import com.fasterxml.jackson.annotation.JsonFormat
+import team.mozu.dsm.domain.item.model.Item
 import java.time.LocalDateTime
 
 data class ItemDetailResponse(
@@ -18,4 +19,24 @@ data class ItemDetailResponse(
     val isDeleted: Boolean,
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
     val createdAt: LocalDateTime
-)
+) {
+    companion object {
+        fun from(item: Item): ItemDetailResponse {
+            return ItemDetailResponse(
+                itemId = item.id!!,
+                itemName = item.itemName,
+                itemLogo = item.itemLogo,
+                itemInfo = item.itemInfo,
+                money = item.money,
+                debt = item.debt,
+                capital = item.capital,
+                profit = item.profit,
+                profitOg = item.profitOg,
+                profitBenefit = item.profitBenefit,
+                netProfit = item.netProfit,
+                isDeleted = item.isDeleted,
+                createdAt = item.createdAt
+            )
+        }
+    }
+}

--- a/src/main/kotlin/team/mozu/dsm/adapter/in/item/dto/response/ItemResponse.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/in/item/dto/response/ItemResponse.kt
@@ -1,6 +1,17 @@
 package team.mozu.dsm.adapter.`in`.item.dto.response
 
+import team.mozu.dsm.domain.item.model.Item
+
 data class ItemResponse(
     val itemId: Int,
     val itemName: String
-)
+) {
+    companion object {
+        fun from(item: Item): ItemResponse {
+            return ItemResponse(
+                itemId = item.id!!,
+                itemName = item.itemName
+            )
+        }
+    }
+}

--- a/src/main/kotlin/team/mozu/dsm/adapter/in/lesson/dto/response/LessonItemDetailResponse.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/in/lesson/dto/response/LessonItemDetailResponse.kt
@@ -1,5 +1,9 @@
 package team.mozu.dsm.adapter.`in`.lesson.dto.response
 
+import team.mozu.dsm.application.port.out.lesson.dto.LessonItemDetailProjection
+import team.mozu.dsm.domain.item.model.Item
+import kotlin.math.roundToInt
+
 data class LessonItemDetailResponse(
     val itemId: Int,
     val itemName: String,
@@ -16,4 +20,48 @@ data class LessonItemDetailResponse(
     val profitOg: Long,
     val profitBen: Long,
     val netProfit: Long
-)
+) {
+    companion object {
+        fun of(item: Item, projection: LessonItemDetailProjection, curInvRound: Int): LessonItemDetailResponse {
+            val moneyList = listOf(
+                projection.round1Price,
+                projection.round2Price,
+                projection.round3Price,
+                projection.round4Price ?: 0,
+                projection.round5Price ?: 0
+            ).take(curInvRound)
+
+            val profitMoney = if (projection.preMoney != 0L) {
+                projection.curMoney - projection.preMoney
+            } else {
+                0L
+            }
+
+            val profitNum = if (projection.preMoney != 0L) {
+                ((profitMoney.toDouble() * 100 / projection.preMoney) * 100).roundToInt() / 100.0
+            } else {
+                0.0
+            }
+
+            val formattedProfitNum = if (profitNum > 0) "+$profitNum%" else "$profitNum%"
+
+            return LessonItemDetailResponse(
+                itemId = item.id!!,
+                itemName = item.itemName,
+                itemLogo = item.itemLogo,
+                nowMoney = projection.curMoney,
+                profitMoney = profitMoney,
+                profitNum = formattedProfitNum,
+                moneyList = moneyList,
+                itemInfo = item.itemInfo,
+                money = item.money,
+                debt = item.debt,
+                capital = item.capital,
+                profit = item.profit,
+                profitOg = item.profitOg,
+                profitBen = item.profitBenefit,
+                netProfit = item.netProfit
+            )
+        }
+    }
+}

--- a/src/main/kotlin/team/mozu/dsm/adapter/in/lesson/dto/response/LessonResponse.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/in/lesson/dto/response/LessonResponse.kt
@@ -1,6 +1,10 @@
 package team.mozu.dsm.adapter.`in`.lesson.dto.response
 
 import com.fasterxml.jackson.annotation.JsonFormat
+import team.mozu.dsm.domain.article.model.Article
+import team.mozu.dsm.domain.item.model.Item
+import team.mozu.dsm.domain.lesson.model.Lesson
+import team.mozu.dsm.domain.lesson.model.LessonItem
 import java.time.LocalDateTime
 import java.util.UUID
 
@@ -18,13 +22,50 @@ data class LessonResponse(
     val createdAt: LocalDateTime,
     val lessonItems: List<LessonItemResponse>,
     val lessonArticles: List<LessonArticleResponse>
-)
+) {
+    companion object {
+        fun of(
+            lesson: Lesson,
+            lessonItems: List<LessonItemResponse>,
+            lessonArticles: List<LessonArticleResponse>
+        ): LessonResponse {
+            return LessonResponse(
+                id = lesson.id!!,
+                name = lesson.lessonName,
+                maxInvRound = lesson.maxInvRound,
+                curInvRound = lesson.curInvRound,
+                baseMoney = lesson.baseMoney,
+                lessonNum = lesson.lessonNum,
+                isInProgress = lesson.isInProgress,
+                isStarred = lesson.isStarred,
+                isDeleted = lesson.isDeleted,
+                createdAt = lesson.createdAt!!,
+                lessonItems = lessonItems,
+                lessonArticles = lessonArticles
+            )
+        }
+    }
+}
 
 data class LessonItemResponse(
     val itemId: Int,
     val itemName: String,
     val money: List<Long>
-)
+) {
+    companion object {
+        fun of(item: Item, lessonItem: LessonItem): LessonItemResponse {
+            return LessonItemResponse(
+                itemId = item.id!!,
+                itemName = item.itemName,
+                money = listOf(
+                    lessonItem.round1Price,
+                    lessonItem.round2Price,
+                    lessonItem.round3Price
+                ) + listOfNotNull(lessonItem.round4Price, lessonItem.round5Price, lessonItem.endPrice)
+            )
+        }
+    }
+}
 
 data class LessonArticleResponse(
     val investmentRound: Int,
@@ -34,4 +75,13 @@ data class LessonArticleResponse(
 data class ArticleResponse(
     val articleId: UUID,
     val title: String
-)
+) {
+    companion object {
+        fun from(article: Article): ArticleResponse {
+            return ArticleResponse(
+                articleId = article.id!!,
+                title = article.articleName
+            )
+        }
+    }
+}

--- a/src/main/kotlin/team/mozu/dsm/adapter/in/lesson/dto/response/LessonRoundItemResponse.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/in/lesson/dto/response/LessonRoundItemResponse.kt
@@ -1,5 +1,8 @@
 package team.mozu.dsm.adapter.`in`.lesson.dto.response
 
+import team.mozu.dsm.application.port.out.lesson.dto.LessonRoundItemProjection
+import kotlin.math.roundToInt
+
 data class LessonRoundItemResponse(
     val itemId: Int,
     val itemName: String,
@@ -7,4 +10,31 @@ data class LessonRoundItemResponse(
     val nowMoney: Long,
     val profitMoney: Long,
     val profitNum: String
-)
+) {
+    companion object {
+        fun from(projection: LessonRoundItemProjection): LessonRoundItemResponse {
+            val profitMoney = if (projection.preMoney != 0L) {
+                projection.curMoney - projection.preMoney
+            } else {
+                0L
+            }
+
+            val profitNum = if (projection.preMoney != 0L) {
+                ((profitMoney.toDouble() * 100 / projection.preMoney) * 100).roundToInt() / 100.0
+            } else {
+                0.0
+            }
+
+            val formattedProfitNum = if (profitNum > 0) "+$profitNum%" else "$profitNum%"
+
+            return LessonRoundItemResponse(
+                itemId = projection.itemId,
+                itemName = projection.itemName,
+                itemLogo = projection.itemLogo,
+                nowMoney = projection.curMoney,
+                profitMoney = profitMoney,
+                profitNum = formattedProfitNum
+            )
+        }
+    }
+}

--- a/src/main/kotlin/team/mozu/dsm/adapter/in/team/dto/response/StockResponse.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/in/team/dto/response/StockResponse.kt
@@ -1,5 +1,7 @@
 package team.mozu.dsm.adapter.`in`.team.dto.response
 
+import team.mozu.dsm.domain.lesson.model.LessonItem
+import team.mozu.dsm.domain.team.model.Stock
 import java.util.UUID
 
 data class StockResponse(
@@ -13,4 +15,34 @@ data class StockResponse(
     val valuationMoney: Long,
     val valProfit: Long,
     val profitNum: Double
-)
+) {
+    companion object {
+        fun of(stock: Stock, lessonItem: LessonItem, currentRound: Int, previousRound: Int): StockResponse {
+            val currentPrice = lessonItem.getPriceByRound(currentRound) ?: lessonItem.endPrice
+            val previousPrice = lessonItem.getPriceByRound(previousRound) ?: lessonItem.endPrice
+
+            val currentValuation = currentPrice * stock.quantity
+            val previousValuation = previousPrice * stock.quantity
+            val valProfit = currentValuation - previousValuation
+
+            val profitNum = if (previousValuation > 0) {
+                (valProfit.toDouble() / previousValuation.toDouble()) * 100
+            } else {
+                0.0
+            }
+
+            return StockResponse(
+                id = stock.id!!,
+                itemId = stock.itemId,
+                itemName = stock.itemName,
+                avgPurchasePrice = stock.avgPurchasePrice,
+                quantity = stock.quantity,
+                totalMoney = stock.buyMoney,
+                nowMoney = currentPrice,
+                valuationMoney = currentValuation,
+                valProfit = valProfit,
+                profitNum = profitNum
+            )
+        }
+    }
+}

--- a/src/main/kotlin/team/mozu/dsm/adapter/in/team/dto/response/TeamDetailResponse.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/in/team/dto/response/TeamDetailResponse.kt
@@ -1,5 +1,7 @@
 package team.mozu.dsm.adapter.`in`.team.dto.response
 
+import team.mozu.dsm.domain.lesson.model.Lesson
+import team.mozu.dsm.domain.team.model.Team
 import java.util.UUID
 
 data class TeamDetailResponse(
@@ -13,4 +15,41 @@ data class TeamDetailResponse(
     val maxInvRound: Int,
     val valProfit: Long,
     val profitNum: String
-)
+) {
+    companion object {
+        fun of(
+            team: Team,
+            lesson: Lesson,
+            currentStockValuation: Long,
+            previousStockValuation: Long
+        ): TeamDetailResponse {
+            val actualTotalMoney = team.cashMoney + currentStockValuation
+            val previousTotalMoney = team.cashMoney + previousStockValuation
+            val currentTotalValProfit = actualTotalMoney - previousTotalMoney
+
+            val profitNum = if (previousTotalMoney > 0) {
+                (currentTotalValProfit.toDouble() / previousTotalMoney.toDouble()) * 100
+            } else {
+                0.0
+            }
+
+            val formattedProfitNum = when {
+                profitNum > 0 -> "+%.2f%%".format(profitNum)
+                else -> "%.2f%%".format(profitNum)
+            }
+
+            return TeamDetailResponse(
+                id = team.id!!,
+                teamName = team.teamName,
+                baseMoney = lesson.baseMoney,
+                totalMoney = actualTotalMoney,
+                cashMoney = team.cashMoney,
+                valuationMoney = currentStockValuation,
+                curInvRound = lesson.curInvRound,
+                maxInvRound = lesson.maxInvRound,
+                valProfit = currentTotalValProfit,
+                profitNum = formattedProfitNum
+            )
+        }
+    }
+}

--- a/src/main/kotlin/team/mozu/dsm/adapter/in/team/dto/response/TeamRankResponse.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/in/team/dto/response/TeamRankResponse.kt
@@ -1,5 +1,6 @@
 package team.mozu.dsm.adapter.`in`.team.dto.response
 
+import team.mozu.dsm.domain.team.model.Team
 import java.util.UUID
 
 data class TeamRankResponse(
@@ -8,4 +9,16 @@ data class TeamRankResponse(
     val schoolName: String,
     val totalMoney: Long,
     val isMyTeam: Boolean
-)
+) {
+    companion object {
+        fun of(team: Team, totalMoney: Long, myTeamId: UUID): TeamRankResponse {
+            return TeamRankResponse(
+                id = team.id!!,
+                teamName = team.teamName,
+                schoolName = team.schoolName,
+                totalMoney = totalMoney,
+                isMyTeam = team.id == myTeamId
+            )
+        }
+    }
+}

--- a/src/main/kotlin/team/mozu/dsm/adapter/in/team/dto/response/TeamResultResponse.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/in/team/dto/response/TeamResultResponse.kt
@@ -1,5 +1,7 @@
 package team.mozu.dsm.adapter.`in`.team.dto.response
 
+import team.mozu.dsm.domain.lesson.model.Lesson
+import team.mozu.dsm.domain.team.model.Team
 import java.util.UUID
 
 data class TeamResultResponse(
@@ -13,4 +15,45 @@ data class TeamResultResponse(
     val valProfit: Long,
     val profitNum: String,
     val orderCount: Int
-)
+) {
+    companion object {
+        fun of(
+            team: Team,
+            lesson: Lesson,
+            currentStockValuation: Long,
+            totalBuyMoney: Long,
+            orderCount: Int
+        ): TeamResultResponse {
+            // 실제 총 자산 = 현금 + 주식 평가액
+            val actualTotalMoney = team.cashMoney + currentStockValuation
+
+            // 평가손익 = 총 자산 - 초기 자산
+            val valProfit = actualTotalMoney - lesson.baseMoney
+
+            // 수익률 = ((최종 자산 - 초기 자산) / 초기 자산) * 100
+            val profitNum = if (lesson.baseMoney > 0) {
+                ((actualTotalMoney.toDouble() - lesson.baseMoney.toDouble()) / lesson.baseMoney.toDouble()) * 100
+            } else {
+                0.0
+            }
+
+            val formattedProfitNum = when {
+                profitNum > 0 -> "+%.2f%%".format(profitNum)
+                else -> "%.2f%%".format(profitNum)
+            }
+
+            return TeamResultResponse(
+                id = team.id!!,
+                teamName = team.teamName,
+                baseMoney = lesson.baseMoney,
+                totalMoney = actualTotalMoney,
+                investingMoney = totalBuyMoney,
+                availableMoney = team.cashMoney,
+                invRound = lesson.curInvRound,
+                valProfit = valProfit,
+                profitNum = formattedProfitNum,
+                orderCount = orderCount
+            )
+        }
+    }
+}

--- a/src/main/kotlin/team/mozu/dsm/adapter/in/team/dto/response/TradingDetailResponse.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/in/team/dto/response/TradingDetailResponse.kt
@@ -1,5 +1,8 @@
 package team.mozu.dsm.adapter.`in`.team.dto.response
 
+import team.mozu.dsm.domain.lesson.model.LessonItem
+import team.mozu.dsm.domain.team.model.Stock
+
 data class TradingDetailResponse(
     val itemId: Int,
     val itemName: String,
@@ -9,4 +12,30 @@ data class TradingDetailResponse(
     val valuationAmount: Long, // 평가금액 (보유 주식수 × 현재가)
     val profitLoss: Long, // 평가손익
     val profitLossRate: Double // 수익률 (%)
-)
+) {
+    companion object {
+        fun of(stock: Stock, lessonItem: LessonItem, currentRound: Int): TradingDetailResponse {
+            val currentPrice = lessonItem.getPriceByRound(currentRound) ?: lessonItem.endPrice
+            val valuationAmount = currentPrice * stock.quantity
+            val totalPurchaseAmount = stock.buyMoney
+            val profitLoss = valuationAmount - totalPurchaseAmount
+
+            val profitLossRate = if (totalPurchaseAmount > 0) {
+                (profitLoss.toDouble() / totalPurchaseAmount.toDouble()) * 100
+            } else {
+                0.0
+            }
+
+            return TradingDetailResponse(
+                itemId = stock.itemId,
+                itemName = stock.itemName,
+                holdingQuantity = stock.quantity,
+                purchasePrice = totalPurchaseAmount,
+                currentPrice = currentPrice,
+                valuationAmount = valuationAmount,
+                profitLoss = profitLoss,
+                profitLossRate = profitLossRate
+            )
+        }
+    }
+}

--- a/src/main/kotlin/team/mozu/dsm/adapter/out/article/mapper/ArticleMapper.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/out/article/mapper/ArticleMapper.kt
@@ -2,8 +2,6 @@ package team.mozu.dsm.adapter.out.article.mapper
 
 import org.mapstruct.Mapper
 import org.mapstruct.Mapping
-import team.mozu.dsm.adapter.`in`.article.dto.response.ArticleResponse
-import team.mozu.dsm.adapter.`in`.article.dto.response.ArticleDetailResponse
 import team.mozu.dsm.adapter.out.article.entity.ArticleJpaEntity
 import team.mozu.dsm.adapter.out.organ.entity.OrganJpaEntity
 import team.mozu.dsm.domain.article.model.Article
@@ -13,11 +11,6 @@ abstract class ArticleMapper {
 
     @Mapping(target = "organId", source = "organ.id")
     abstract fun toModel(entity: ArticleJpaEntity): Article
-
-    @Mapping(target = "articleImg", source = "articleImage")
-    abstract fun toDetailResponse(model: Article): ArticleDetailResponse
-
-    abstract fun toResponse(model: Article): ArticleResponse
 
     fun toEntity(model: Article, organ: OrganJpaEntity): ArticleJpaEntity {
         return ArticleJpaEntity(

--- a/src/main/kotlin/team/mozu/dsm/adapter/out/item/mapper/ItemMapper.kt
+++ b/src/main/kotlin/team/mozu/dsm/adapter/out/item/mapper/ItemMapper.kt
@@ -2,8 +2,6 @@ package team.mozu.dsm.adapter.out.item.mapper
 
 import org.mapstruct.Mapper
 import org.mapstruct.Mapping
-import team.mozu.dsm.adapter.`in`.item.dto.response.ItemResponse
-import team.mozu.dsm.adapter.`in`.item.dto.response.ItemDetailResponse
 import team.mozu.dsm.adapter.out.item.entity.ItemJpaEntity
 import team.mozu.dsm.adapter.out.organ.entity.OrganJpaEntity
 import team.mozu.dsm.domain.item.model.Item
@@ -13,12 +11,6 @@ abstract class ItemMapper {
 
     @Mapping(target = "organId", source = "organ.id")
     abstract fun toModel(entity: ItemJpaEntity): Item
-
-    @Mapping(target = "itemId", source = "id")
-    abstract fun toDetailResponse(model: Item): ItemDetailResponse
-
-    @Mapping(target = "itemId", source = "id")
-    abstract fun toResponse(model: Item): ItemResponse
 
     fun toEntity(model: Item, organ: OrganJpaEntity): ItemJpaEntity {
         return ItemJpaEntity(

--- a/src/main/kotlin/team/mozu/dsm/application/service/article/CreateArticleService.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/service/article/CreateArticleService.kt
@@ -4,7 +4,6 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import team.mozu.dsm.adapter.`in`.article.dto.request.ArticleRequest
 import team.mozu.dsm.adapter.`in`.article.dto.response.ArticleDetailResponse
-import team.mozu.dsm.adapter.out.article.mapper.ArticleMapper
 import team.mozu.dsm.application.port.`in`.article.CreateArticleUseCase
 import team.mozu.dsm.application.port.out.article.CommandArticlePort
 import team.mozu.dsm.application.port.out.auth.SecurityPort
@@ -16,7 +15,6 @@ import java.time.LocalDateTime
 class CreateArticleService(
     private val securityPort: SecurityPort,
     private val articlePort: CommandArticlePort,
-    private val articleMapper: ArticleMapper,
     private val s3Port: S3Port
 ) : CreateArticleUseCase {
 
@@ -40,6 +38,6 @@ class CreateArticleService(
 
         val saved = articlePort.save(article)
 
-        return articleMapper.toDetailResponse(saved)
+        return ArticleDetailResponse.from(saved)
     }
 }

--- a/src/main/kotlin/team/mozu/dsm/application/service/article/QueryArticleDetailService.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/service/article/QueryArticleDetailService.kt
@@ -3,7 +3,6 @@ package team.mozu.dsm.application.service.article
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import team.mozu.dsm.adapter.`in`.article.dto.response.ArticleDetailResponse
-import team.mozu.dsm.adapter.out.article.mapper.ArticleMapper
 import team.mozu.dsm.application.exception.article.ArticleNotFoundException
 import team.mozu.dsm.application.port.`in`.article.QueryArticleDetailUseCase
 import team.mozu.dsm.application.port.out.article.QueryArticlePort
@@ -11,13 +10,12 @@ import java.util.UUID
 
 @Service
 class QueryArticleDetailService(
-    private val queryArticlePort: QueryArticlePort,
-    private val articleMapper: ArticleMapper
+    private val queryArticlePort: QueryArticlePort
 ) : QueryArticleDetailUseCase {
 
     @Transactional(readOnly = true)
     override fun execute(id: UUID): ArticleDetailResponse =
-        articleMapper.toDetailResponse(
+        ArticleDetailResponse.from(
             queryArticlePort.findById(id)
                 ?: throw ArticleNotFoundException
         )

--- a/src/main/kotlin/team/mozu/dsm/application/service/article/QueryArticlesService.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/service/article/QueryArticlesService.kt
@@ -3,7 +3,6 @@ package team.mozu.dsm.application.service.article
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import team.mozu.dsm.adapter.`in`.article.dto.response.ArticleResponse
-import team.mozu.dsm.adapter.out.article.mapper.ArticleMapper
 import team.mozu.dsm.application.port.`in`.article.QueryArticlesUseCase
 import team.mozu.dsm.application.port.out.article.QueryArticlePort
 import team.mozu.dsm.application.port.out.auth.SecurityPort
@@ -11,12 +10,11 @@ import team.mozu.dsm.application.port.out.auth.SecurityPort
 @Service
 class QueryArticlesService(
     private val queryArticlePort: QueryArticlePort,
-    private val articleMapper: ArticleMapper,
     private val securityPort: SecurityPort
 ) : QueryArticlesUseCase {
 
     @Transactional(readOnly = true)
     override fun execute(): List<ArticleResponse> =
         queryArticlePort.findAllByOrganId(securityPort.getCurrentOrgan().id!!)
-            .map { articleMapper.toResponse(it) }
+            .map { ArticleResponse.from(it) }
 }

--- a/src/main/kotlin/team/mozu/dsm/application/service/article/UpdateArticleService.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/service/article/UpdateArticleService.kt
@@ -4,7 +4,6 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import team.mozu.dsm.adapter.`in`.article.dto.request.UpdateArticleRequest
 import team.mozu.dsm.adapter.`in`.article.dto.response.ArticleDetailResponse
-import team.mozu.dsm.adapter.out.article.mapper.ArticleMapper
 import team.mozu.dsm.application.exception.article.ArticleNotFoundException
 import team.mozu.dsm.application.exception.article.CannotDeleteArticleException
 import team.mozu.dsm.application.port.`in`.article.UpdateArticleUseCase
@@ -19,7 +18,6 @@ import java.util.UUID
 class UpdateArticleService(
     private val commandArticlePort: CommandArticlePort,
     private val queryArticlePort: QueryArticlePort,
-    private val articleMapper: ArticleMapper,
     private val securityPort: SecurityPort,
     private val s3Port: S3Port
 ) : UpdateArticleUseCase {
@@ -57,6 +55,6 @@ class UpdateArticleService(
         }
 
         val saveArticle = commandArticlePort.save(article.updateArticle(request, newImageUrl))
-        return articleMapper.toDetailResponse(saveArticle)
+        return ArticleDetailResponse.from(saveArticle)
     }
 }

--- a/src/main/kotlin/team/mozu/dsm/application/service/item/CreateItemService.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/service/item/CreateItemService.kt
@@ -4,7 +4,6 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import team.mozu.dsm.adapter.`in`.item.dto.request.ItemRequest
 import team.mozu.dsm.adapter.`in`.item.dto.response.ItemDetailResponse
-import team.mozu.dsm.adapter.out.item.mapper.ItemMapper
 import team.mozu.dsm.application.port.`in`.item.CreateItemUseCase
 import team.mozu.dsm.application.port.out.auth.SecurityPort
 import team.mozu.dsm.application.port.out.item.CommandItemPort
@@ -16,7 +15,6 @@ import java.time.LocalDateTime
 class CreateItemService(
     private val securityPort: SecurityPort,
     private val itemPort: CommandItemPort,
-    private val itemMapper: ItemMapper,
     private val s3Port: S3Port
 ) : CreateItemUseCase {
 
@@ -48,6 +46,6 @@ class CreateItemService(
 
         val saved = itemPort.save(item)
 
-        return itemMapper.toDetailResponse(saved)
+        return ItemDetailResponse.from(saved)
     }
 }

--- a/src/main/kotlin/team/mozu/dsm/application/service/item/QueryItemDetailService.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/service/item/QueryItemDetailService.kt
@@ -3,20 +3,18 @@ package team.mozu.dsm.application.service.item
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import team.mozu.dsm.adapter.`in`.item.dto.response.ItemDetailResponse
-import team.mozu.dsm.adapter.out.item.mapper.ItemMapper
 import team.mozu.dsm.application.exception.item.ItemNotFoundException
 import team.mozu.dsm.application.port.`in`.item.QueryItemDetailUseCase
 import team.mozu.dsm.application.port.out.item.QueryItemPort
 
 @Service
 class QueryItemDetailService(
-    private val queryItemPort: QueryItemPort,
-    private val itemMapper: ItemMapper
+    private val queryItemPort: QueryItemPort
 ) : QueryItemDetailUseCase {
 
     @Transactional(readOnly = true)
     override fun execute(id: Int): ItemDetailResponse =
-        itemMapper.toDetailResponse(
+        ItemDetailResponse.from(
             queryItemPort.findById(id)
                 ?: throw ItemNotFoundException
         )

--- a/src/main/kotlin/team/mozu/dsm/application/service/item/QueryItemsService.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/service/item/QueryItemsService.kt
@@ -3,7 +3,6 @@ package team.mozu.dsm.application.service.item
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import team.mozu.dsm.adapter.`in`.item.dto.response.ItemResponse
-import team.mozu.dsm.adapter.out.item.mapper.ItemMapper
 import team.mozu.dsm.application.port.`in`.item.QueryItemsUseCase
 import team.mozu.dsm.application.port.out.auth.SecurityPort
 import team.mozu.dsm.application.port.out.item.QueryItemPort
@@ -11,12 +10,11 @@ import team.mozu.dsm.application.port.out.item.QueryItemPort
 @Service
 class QueryItemsService(
     private val queryItemPort: QueryItemPort,
-    private val itemMapper: ItemMapper,
     private val securityPort: SecurityPort
 ) : QueryItemsUseCase {
 
     @Transactional(readOnly = true)
     override fun execute(): List<ItemResponse> =
         queryItemPort.findAllByOrganId(securityPort.getCurrentOrgan().id!!)
-            .map { itemMapper.toResponse(it) }
+            .map { ItemResponse.from(it) }
 }

--- a/src/main/kotlin/team/mozu/dsm/application/service/item/UpdateItemService.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/service/item/UpdateItemService.kt
@@ -4,7 +4,6 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import team.mozu.dsm.adapter.`in`.item.dto.request.UpdateItemRequest
 import team.mozu.dsm.adapter.`in`.item.dto.response.ItemDetailResponse
-import team.mozu.dsm.adapter.out.item.mapper.ItemMapper
 import team.mozu.dsm.application.exception.item.ItemNotFoundException
 import team.mozu.dsm.application.exception.lesson.CannotDeleteLessonException
 import team.mozu.dsm.application.port.`in`.item.UpdateItemUseCase
@@ -18,7 +17,6 @@ import java.time.LocalDateTime
 class UpdateItemService(
     private val commandItemPort: CommandItemPort,
     private val queryItemPort: QueryItemPort,
-    private val itemMapper: ItemMapper,
     private val securityPort: SecurityPort,
     private val s3Port: S3Port
 ) : UpdateItemUseCase {
@@ -70,6 +68,6 @@ class UpdateItemService(
         )
 
         val saved = commandItemPort.save(updated)
-        return itemMapper.toDetailResponse(saved)
+        return ItemDetailResponse.from(saved)
     }
 }

--- a/src/main/kotlin/team/mozu/dsm/application/service/lesson/CreateLessonService.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/service/lesson/CreateLessonService.kt
@@ -53,20 +53,6 @@ class CreateLessonService(
         // LessonArticles DTO 변환
         val lessonArticleResponses = lessonFacade.toLessonArticleResponses(lessonArticles)
 
-        // 최종 LessonResponse 반환
-        return LessonResponse(
-            id = saved.id!!,
-            name = saved.lessonName,
-            maxInvRound = saved.maxInvRound,
-            curInvRound = saved.curInvRound,
-            baseMoney = saved.baseMoney,
-            lessonNum = saved.lessonNum,
-            isInProgress = saved.isInProgress,
-            isStarred = saved.isStarred,
-            isDeleted = saved.isDeleted,
-            createdAt = saved.createdAt!!,
-            lessonItems = lessonItemResponses,
-            lessonArticles = lessonArticleResponses
-        )
+        return LessonResponse.of(saved, lessonItemResponses, lessonArticleResponses)
     }
 }

--- a/src/main/kotlin/team/mozu/dsm/application/service/lesson/QueryLessonItemDetailService.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/service/lesson/QueryLessonItemDetailService.kt
@@ -9,7 +9,6 @@ import team.mozu.dsm.application.port.`in`.lesson.QueryLessonItemDetailUseCase
 import team.mozu.dsm.application.port.out.item.QueryItemPort
 import team.mozu.dsm.application.port.out.lesson.QueryLessonItemPort
 import team.mozu.dsm.application.port.out.lesson.QueryLessonPort
-import kotlin.math.roundToInt
 
 @Service
 class QueryLessonItemDetailService(
@@ -26,43 +25,6 @@ class QueryLessonItemDetailService(
             ?: throw ItemNotFoundException
         val lessonItem = lessonItemPort.findItemDetailByLessonIdAndItemId(lesson.id!!, item.id!!)
 
-        val moneyList = listOf(
-            lessonItem.round1Price,
-            lessonItem.round2Price,
-            lessonItem.round3Price,
-            lessonItem.round4Price ?: 0,
-            lessonItem.round5Price ?: 0
-        ).take(lesson.curInvRound)
-
-        val profitMoney = if (lessonItem.preMoney != 0L) {
-            lessonItem.curMoney - lessonItem.preMoney
-        } else {
-            0
-        }
-        val profitNum = if (lessonItem.preMoney != 0L) {
-            ((profitMoney.toDouble() * 100 / lessonItem.preMoney) * 100).roundToInt() / 100.0
-        } else {
-            0.0
-        }
-
-        val formattedProfitNum = if (profitNum > 0) "+$profitNum%" else "$profitNum%"
-
-        return LessonItemDetailResponse(
-            itemId = item.id,
-            itemName = item.itemName,
-            itemLogo = item.itemLogo,
-            nowMoney = lessonItem.curMoney,
-            profitMoney = profitMoney,
-            profitNum = formattedProfitNum,
-            moneyList = moneyList,
-            itemInfo = item.itemInfo,
-            money = item.money,
-            debt = item.debt,
-            capital = item.capital,
-            profit = item.profit,
-            profitOg = item.profitOg,
-            profitBen = item.profitBenefit,
-            netProfit = item.netProfit
-        )
+        return LessonItemDetailResponse.of(item, lessonItem, lesson.curInvRound)
     }
 }

--- a/src/main/kotlin/team/mozu/dsm/application/service/lesson/QueryLessonRoundItemsService.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/service/lesson/QueryLessonRoundItemsService.kt
@@ -7,7 +7,6 @@ import team.mozu.dsm.application.exception.lesson.LessonNotFoundException
 import team.mozu.dsm.application.port.`in`.lesson.QueryLessonRoundItemsUseCase
 import team.mozu.dsm.application.port.out.lesson.QueryLessonItemPort
 import team.mozu.dsm.application.port.out.lesson.QueryLessonPort
-import kotlin.math.roundToInt
 
 @Service
 class QueryLessonRoundItemsService(
@@ -19,31 +18,8 @@ class QueryLessonRoundItemsService(
     override fun execute(lessonNum: String): List<LessonRoundItemResponse> {
         val lesson = lessonPort.findByLessonNum(lessonNum)
             ?: throw LessonNotFoundException
-        val lessonItems = lessonItemPort.findAllRoundItemsByLessonId(lesson.id!!)
 
-        return lessonItems.map { item ->
-            val nowMoney = item.curMoney
-            val profitMoney = if (item.preMoney != 0L) {
-                item.curMoney - item.preMoney
-            } else {
-                0
-            }
-            val profitNum = if (item.preMoney != 0L) {
-                ((profitMoney.toDouble() * 100 / item.preMoney) * 100).roundToInt() / 100.0
-            } else {
-                0.0
-            }
-
-            val formattedProfitNum = if (profitNum > 0) "+$profitNum%" else "$profitNum%"
-
-            LessonRoundItemResponse(
-                itemId = item.itemId,
-                itemName = item.itemName,
-                itemLogo = item.itemLogo,
-                nowMoney = nowMoney,
-                profitMoney = profitMoney,
-                profitNum = formattedProfitNum
-            )
-        }
+        return lessonItemPort.findAllRoundItemsByLessonId(lesson.id!!)
+            .map { LessonRoundItemResponse.from(it) }
     }
 }

--- a/src/main/kotlin/team/mozu/dsm/application/service/lesson/UpdateLessonService.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/service/lesson/UpdateLessonService.kt
@@ -62,20 +62,13 @@ class UpdateLessonService(
         // LessonArticles DTO 변환
         val lessonArticleResponses = lessonFacade.toLessonArticleResponses(lessonArticles)
 
-        // 최종 LessonResponse 반환
-        return LessonResponse(
-            id = lesson.id,
-            name = command.lessonName,
+        // 업데이트된 값을 반영한 lesson 객체 생성
+        val updatedLesson = lesson.copy(
+            lessonName = command.lessonName,
             maxInvRound = command.lessonRound,
-            curInvRound = lesson.curInvRound,
-            baseMoney = command.baseMoney,
-            lessonNum = lesson.lessonNum,
-            isInProgress = lesson.isInProgress,
-            isStarred = lesson.isStarred,
-            isDeleted = lesson.isDeleted,
-            createdAt = lesson.createdAt!!,
-            lessonItems = lessonItemResponses,
-            lessonArticles = lessonArticleResponses
+            baseMoney = command.baseMoney
         )
+
+        return LessonResponse.of(updatedLesson, lessonItemResponses, lessonArticleResponses)
     }
 }

--- a/src/main/kotlin/team/mozu/dsm/application/service/lesson/facade/LessonFacade.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/service/lesson/facade/LessonFacade.kt
@@ -110,20 +110,8 @@ class LessonFacade(
         // LessonItem 도메인을 LessonItemResponse DTO로 변환
         // 존재하지 않거나 삭제된 Item은 제외
         return lessonItems.mapNotNull { lessonItem ->
-            val item = itemMap[lessonItem.lessonItemId.itemId]
-            if (item == null) {
-                null
-            } else {
-                LessonItemResponse(
-                    itemId = item.id!!,
-                    itemName = item.itemName,
-                    money = listOf(
-                        lessonItem.round1Price, // 0번째 -> 1차
-                        lessonItem.round2Price, // 1번째 -> 2차
-                        lessonItem.round3Price // 2번째 -> 3차
-                    ) + listOfNotNull(lessonItem.round4Price, lessonItem.round5Price, lessonItem.endPrice) // 4차, 5차, 종료가
-                )
-            }
+            val item = itemMap[lessonItem.lessonItemId.itemId] ?: return@mapNotNull null
+            LessonItemResponse.of(item, lessonItem)
         }
     }
 
@@ -142,10 +130,7 @@ class LessonFacade(
                     articles = articles.map { lessonArticle ->
                         val article = articleMap[lessonArticle.lessonArticleId.articleId]
                             ?: throw ArticleNotFoundException
-                        ArticleResponse(
-                            articleId = article.id!!,
-                            title = article.articleName
-                        )
+                        ArticleResponse.from(article)
                     }
                 )
             }

--- a/src/main/kotlin/team/mozu/dsm/application/service/team/QueryHoldStocksService.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/service/team/QueryHoldStocksService.kt
@@ -23,13 +23,11 @@ class QueryHoldStocksService(
     @Transactional(readOnly = true)
     override fun execute(teamId: UUID): List<StockResponse> {
         return try {
-            val team = queryTeamPort.findById(teamId) ?: run {
-                throw TeamNotFoundException
-            }
+            val team = queryTeamPort.findById(teamId)
+                ?: throw TeamNotFoundException
 
-            val lesson = queryLessonPort.findByLessonNum(team.lessonNum) ?: run {
-                throw LessonNotFoundException
-            }
+            val lesson = queryLessonPort.findByLessonNum(team.lessonNum)
+                ?: throw LessonNotFoundException
 
             val stocks = queryStockPort.findAllByTeamId(teamId)
                 .filter { it.id != null && it.quantity > 0 }
@@ -47,32 +45,7 @@ class QueryHoldStocksService(
 
             stocks.mapNotNull { stock ->
                 val lessonItem = lessonItemMap[stock.itemId] ?: return@mapNotNull null
-
-                val currentPrice = lessonItem.getPriceByRound(currentRound) ?: lessonItem.endPrice
-                val previousPrice = lessonItem.getPriceByRound(previousRound) ?: lessonItem.endPrice
-
-                val currentValuation = currentPrice * stock.quantity
-                val previousValuation = previousPrice * stock.quantity
-                val valProfit = currentValuation - previousValuation
-
-                val profitNum = if (previousValuation > 0) {
-                    (valProfit.toDouble() / previousValuation.toDouble()) * 100
-                } else {
-                    0.0
-                }
-
-                StockResponse(
-                    id = stock.id!!,
-                    itemId = stock.itemId,
-                    itemName = stock.itemName,
-                    avgPurchasePrice = stock.avgPurchasePrice,
-                    quantity = stock.quantity,
-                    totalMoney = stock.buyMoney,
-                    nowMoney = currentPrice,
-                    valuationMoney = currentValuation,
-                    valProfit = valProfit,
-                    profitNum = profitNum
-                )
+                StockResponse.of(stock, lessonItem, currentRound, previousRound)
             }
         } catch (e: Exception) {
             e.printStackTrace()

--- a/src/main/kotlin/team/mozu/dsm/application/service/team/QueryStocksService.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/service/team/QueryStocksService.kt
@@ -32,9 +32,7 @@ class QueryStocksService(
 
         val lessonItemMap = queryLessonItemPort.findAllByLessonIdAndItemIds(
             lesson.id!!,
-            validStocks
-                .map { it.itemId }
-                .distinct()
+            validStocks.map { it.itemId }.distinct()
         ).associateBy { it.lessonItemId.itemId }
 
         val currentRound = lesson.curInvRound
@@ -44,32 +42,7 @@ class QueryStocksService(
             val lessonItem = lessonItemMap[stock.itemId]
                 ?: throw LessonItemNotFoundException
 
-            val currentPrice = lessonItem.getPriceByRound(currentRound)
-                ?: lessonItem.endPrice
-            val previousPrice = lessonItem.getPriceByRound(previousRound)
-                ?: lessonItem.endPrice
-
-            val currentValuation = currentPrice * stock.quantity
-            val previousValuation = previousPrice * stock.quantity
-            val valProfit = currentValuation - previousValuation
-            val profitNum = if (previousValuation > 0) {
-                (valProfit.toDouble() / previousValuation.toDouble()) * 100
-            } else {
-                0.0
-            }
-
-            StockResponse(
-                id = stock.id!!,
-                itemId = stock.itemId,
-                itemName = stock.itemName,
-                avgPurchasePrice = stock.avgPurchasePrice,
-                quantity = stock.quantity,
-                totalMoney = stock.buyMoney,
-                nowMoney = currentPrice,
-                valuationMoney = currentValuation,
-                valProfit = valProfit,
-                profitNum = profitNum
-            )
+            StockResponse.of(stock, lessonItem, currentRound, previousRound)
         }
     }
 }

--- a/src/main/kotlin/team/mozu/dsm/application/service/team/QueryTeamDetailService.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/service/team/QueryTeamDetailService.kt
@@ -42,7 +42,6 @@ class QueryTeamDetailService(
         val currentStockValuation = stocks.sumOf { stock ->
             val lessonItem = lessonItemMap[stock.itemId]
                 ?: throw LessonItemNotFoundException
-
             val currentPrice = lessonItem.getPriceByRound(currentRound) ?: lessonItem.endPrice
             currentPrice * stock.quantity
         }
@@ -51,42 +50,10 @@ class QueryTeamDetailService(
         val previousStockValuation = stocks.sumOf { stock ->
             val lessonItem = lessonItemMap[stock.itemId]
                 ?: throw LessonItemNotFoundException
-
             val previousPrice = lessonItem.getPriceByRound(previousRound) ?: lessonItem.endPrice
             previousPrice * stock.quantity
         }
 
-        // 실제 총 자산 = 현금 + 주식 평가액 (현재 차수 기준)
-        val actualTotalMoney = team.cashMoney + currentStockValuation
-
-        // 이전 차수 기준 총 자산 = 현금 + 이전 차수 주식 평가액
-        val previousTotalMoney = team.cashMoney + previousStockValuation
-
-        // 총 자산 증감률 (이전 vs 현재 차수)
-        val currentTotalValProfit = actualTotalMoney - previousTotalMoney
-
-        val profitNum = if (previousTotalMoney > 0) {
-            (currentTotalValProfit.toDouble() / previousTotalMoney.toDouble()) * 100
-        } else {
-            0.0
-        }
-
-        val formattedProfitNum = when {
-            profitNum > 0 -> "+%.2f%%".format(profitNum)
-            else -> "%.2f%%".format(profitNum)
-        }
-
-        return TeamDetailResponse(
-            id = teamId,
-            teamName = team.teamName,
-            baseMoney = lesson.baseMoney,
-            totalMoney = actualTotalMoney,
-            cashMoney = team.cashMoney,
-            valuationMoney = currentStockValuation,
-            curInvRound = currentRound,
-            maxInvRound = lesson.maxInvRound,
-            valProfit = currentTotalValProfit,
-            profitNum = formattedProfitNum
-        )
+        return TeamDetailResponse.of(team, lesson, currentStockValuation, previousStockValuation)
     }
 }

--- a/src/main/kotlin/team/mozu/dsm/application/service/team/QueryTeamRanksService.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/service/team/QueryTeamRanksService.kt
@@ -30,13 +30,13 @@ class QueryTeamRanksService(
         // 수익 계산을 위한 차수: 현재 진행 차수(N) + 1 (/team/result와 동일)
         val profitCalculationRound = lesson.curInvRound + 1
 
-        val teamRanks = teams.map { team ->
+        return teams.map { team ->
             // 각 팀의 주식 조회
             val stocks = queryStockPort.findAllByTeamId(team.id!!)
             val stockItemIds = stocks.map { it.itemId }.distinct()
 
             val lessonItemMap = if (stockItemIds.isNotEmpty()) {
-                queryLessonItemPort.findAllByLessonIdAndItemIds(lesson.id!!, stockItemIds)
+                queryLessonItemPort.findAllByLessonIdAndItemIds(lesson.id, stockItemIds)
                     .associateBy { it.lessonItemId.itemId }
             } else {
                 emptyMap()
@@ -52,15 +52,7 @@ class QueryTeamRanksService(
             // 실제 총 자산 = 현금 + 주식 평가액 (/team/result와 동일)
             val actualTotalMoney = team.cashMoney + currentStockValuation
 
-            TeamRankResponse(
-                id = team.id,
-                teamName = team.teamName,
-                schoolName = team.schoolName,
-                totalMoney = actualTotalMoney, // 실시간 계산된 값
-                isMyTeam = team.id == teamId
-            )
-        }.sortedByDescending { it.totalMoney } // 실시간 계산 후 정렬
-
-        return teamRanks
+            TeamRankResponse.of(team, actualTotalMoney, teamId)
+        }.sortedByDescending { it.totalMoney }
     }
 }

--- a/src/main/kotlin/team/mozu/dsm/application/service/team/QueryTeamResultService.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/service/team/QueryTeamResultService.kt
@@ -40,6 +40,7 @@ class QueryTeamResultService(
             emptyMap()
         }
 
+        // 투자중인 금액 (매입한 주식 총액)
         val totalBuyMoney = stocks.sumOf { it.buyMoney }
 
         // 수익 계산을 위한 차수: 현재 진행 차수(N) + 1
@@ -52,35 +53,9 @@ class QueryTeamResultService(
             currentPrice * stock.quantity
         }
 
-        // 실제 총 자산 = 현금 + 주식 평가액
-        val actualTotalMoney = team.cashMoney + currentStockValuation
+        // 주문 수량 조회
+        val orderCount = queryOrderItemPort.countOrderItemsByTeamId(teamId)
 
-        // 평가손익 = 총 자산 - 초기 자산
-        val valProfit = actualTotalMoney - lesson.baseMoney
-
-        // 수익률 = ((최종 자산 - 초기 자산) / 초기 자산) * 100
-        val profitNum = if (lesson.baseMoney > 0) {
-            ((actualTotalMoney.toDouble() - lesson.baseMoney.toDouble()) / lesson.baseMoney.toDouble()) * 100
-        } else {
-            0.0
-        }
-
-        val formattedProfitNum = when {
-            profitNum > 0 -> "+%.2f%%".format(profitNum)
-            else -> "%.2f%%".format(profitNum)
-        }
-
-        return TeamResultResponse(
-            id = team.id!!,
-            teamName = team.teamName,
-            baseMoney = lesson.baseMoney,
-            totalMoney = actualTotalMoney,
-            investingMoney = totalBuyMoney, // 투자중인 금액 (매입한 주식 총액)
-            availableMoney = team.cashMoney, // 주문 가능 금액 (보유 현금)
-            invRound = lesson.curInvRound,
-            valProfit = valProfit,
-            profitNum = formattedProfitNum,
-            orderCount = queryOrderItemPort.countOrderItemsByTeamId(teamId)
-        )
+        return TeamResultResponse.of(team, lesson, currentStockValuation, totalBuyMoney, orderCount)
     }
 }

--- a/src/main/kotlin/team/mozu/dsm/application/service/team/QueryTradingDetailService.kt
+++ b/src/main/kotlin/team/mozu/dsm/application/service/team/QueryTradingDetailService.kt
@@ -43,28 +43,7 @@ class QueryTradingDetailService(
             val lessonItem = lessonItemMap[stock.itemId]
                 ?: throw LessonItemNotFoundException
 
-            val currentPrice = lessonItem.getPriceByRound(currentRound)
-                ?: lessonItem.endPrice
-
-            val valuationAmount = currentPrice * stock.quantity
-            val totalPurchaseAmount = stock.buyMoney // 총 매입금액 사용
-            val profitLoss = valuationAmount - totalPurchaseAmount
-            val profitLossRate = if (totalPurchaseAmount > 0) {
-                (profitLoss.toDouble() / totalPurchaseAmount.toDouble()) * 100
-            } else {
-                0.0
-            }
-
-            TradingDetailResponse(
-                itemId = stock.itemId,
-                itemName = stock.itemName,
-                holdingQuantity = stock.quantity,
-                purchasePrice = totalPurchaseAmount, // 총 매입금액
-                currentPrice = currentPrice,
-                valuationAmount = valuationAmount,
-                profitLoss = profitLoss,
-                profitLossRate = profitLossRate
-            )
+            TradingDetailResponse.of(stock, lessonItem, currentRound)
         }.sortedByDescending { it.valuationAmount } // 평가금액 높은 순으로 정렬
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

- #185

# DTO 리팩토링 - from/of 팩토리 메서드 적용

## 배경 및 목적

### 기존 문제점
1. **Service 계층의 책임 과다**: Service에서 비즈니스 흐름 제어 + DTO 조립 + 계산 로직을 모두 담당
2. **MapStruct 기반 Response 반환의 혼재**: 일부는 Mapper에서, 일부는 Service에서 직접 생성하는 방식이 혼재
3. **DTO 생성 책임 분산**: 변환 로직의 위치가 불명확

### 해결 방향
- **Mapper**: Entity ↔ Domain 변환만 담당
- **from()**: 단일 Domain → Response 변환
- **of()**: 여러 값 조합 + 파생 계산이 필요한 경우
- **생성자**: 필드 1개 또는 단순 값 전달

---

## 설계 고민 - 계산 로직의 위치

### DTO에 계산 로직을 둔 이유
Service와 DTO의 역할을 분리하기 위해 **조회 전용 파생 계산**(수익률, 평가금액, 포맷팅 등)은 DTO로 이동했습니다.

```kotlin
// Before: Service에서 모든 계산 수행 (93줄)
class QueryTeamDetailService {
    override fun execute(...): TeamDetailResponse {
        // 조회
        val stocks = queryStockPort.findAllByTeamId(teamId)
        // 계산
        val currentStockValuation = stocks.sumOf { ... }
        val previousStockValuation = stocks.sumOf { ... }
        val actualTotalMoney = team.cashMoney + currentStockValuation
        val profitNum = ((actualTotalMoney - previousTotalMoney) / previousTotalMoney) * 100
        val formattedProfitNum = "+%.2f%%".format(profitNum)
        // DTO 생성
        return TeamDetailResponse(id = ..., totalMoney = ..., profitNum = ...)
    }
}

// After: Service는 조회만, 계산은 DTO에서 (56줄)
class QueryTeamDetailService {
    override fun execute(...): TeamDetailResponse {
        // 조회
        val stocks = queryStockPort.findAllByTeamId(teamId)
        val currentStockValuation = stocks.sumOf { ... }
        val previousStockValuation = stocks.sumOf { ... }
        // DTO에 위임
        return TeamDetailResponse.of(team, lesson, currentStockValuation, previousStockValuation)
    }
}
```

### DTO vs Service 역할 분리 기준

| 위치 | 역할 | 예시 |
|------|------|------|
| **Service** | DB 조회, 트랜잭션, 도메인 정책 호출 | `queryOrderItemPort.countOrderItemsByTeamId()` |
| **DTO of/from** | 조회 전용 파생 계산, 포맷팅 | 수익률 계산, `+3.5%` 포맷팅 |

**🚫 DTO에 두면 안 되는 것:**
- 정책 판단 (예: 수익률 20% 이상이면 보너스)
- 상태 변경
- DB 저장에 영향 주는 계산
- 다른 도메인 객체 조회/도메인 규칙 호출

### 향후 개선 방향
이번 리팩토링을 통해 Service의 역할이 가벼워졌지만, **반복되는 계산 로직**(수익률 계산, 포맷팅 등)이 여러 DTO에 흩어져 있는 상태입니다.

추후 `ProfitCalculator`와 같은 **공통 계산/포맷팅 유틸리티**를 도입하여 중복을 제거할 예정입니다.

```kotlin
// 현재: 각 DTO에 중복된 계산 로직
data class TeamDetailResponse(...) {
    companion object {
        fun of(...) {
            val profitNum = if (base > 0) (profit / base) * 100 else 0.0
            val formatted = if (profitNum > 0) "+%.2f%%" else "%.2f%%"
            ...
        }
    }
}

// 향후: Calculator로 공통화
@Component
class ProfitCalculator {
    fun calculateProfitRate(profit: Long, base: Long): Double
    fun formatProfitRate(rate: Double): String
}
```

---

## 변경된 Response DTO

### 1. Article 관련
```kotlin
// ArticleResponse.kt
data class ArticleResponse(...) {
    companion object {
        fun from(article: Article): ArticleResponse
    }
}

// ArticleDetailResponse.kt
data class ArticleDetailResponse(...) {
    companion object {
        fun from(article: Article): ArticleDetailResponse
    }
}
```

### 2. Item 관련
```kotlin
// ItemResponse.kt
data class ItemResponse(...) {
    companion object {
        fun from(item: Item): ItemResponse
    }
}

// ItemDetailResponse.kt
data class ItemDetailResponse(...) {
    companion object {
        fun from(item: Item): ItemDetailResponse
    }
}
```

### 3. Lesson 관련
```kotlin
// LessonResponse.kt
data class LessonResponse(...) {
    companion object {
        fun of(lesson: Lesson, lessonItems: List<LessonItemResponse>, lessonArticles: List<LessonArticleResponse>): LessonResponse
    }
}

data class LessonItemResponse(...) {
    companion object {
        fun of(item: Item, lessonItem: LessonItem): LessonItemResponse
    }
}

data class ArticleResponse(...) {  // Lesson 내부용
    companion object {
        fun from(article: Article): ArticleResponse
    }
}

// LessonRoundItemResponse.kt - 수익률 계산 + 포맷팅
data class LessonRoundItemResponse(...) {
    companion object {
        fun from(projection: LessonRoundItemProjection): LessonRoundItemResponse
    }
}

// LessonItemDetailResponse.kt - 수익률 계산 + 포맷팅
data class LessonItemDetailResponse(...) {
    companion object {
        fun of(item: Item, projection: LessonItemDetailProjection, curInvRound: Int): LessonItemDetailResponse
    }
}
```

### 4. Team 관련
```kotlin
// StockResponse.kt - 평가금액, 수익률 계산
data class StockResponse(...) {
    companion object {
        fun of(stock: Stock, lessonItem: LessonItem, currentRound: Int, previousRound: Int): StockResponse
    }
}

// TradingDetailResponse.kt - 평가금액, 수익률 계산
data class TradingDetailResponse(...) {
    companion object {
        fun of(stock: Stock, lessonItem: LessonItem, currentRound: Int): TradingDetailResponse
    }
}

// TeamDetailResponse.kt - 총자산, 수익률 계산 + 포맷팅
data class TeamDetailResponse(...) {
    companion object {
        fun of(team: Team, lesson: Lesson, currentStockValuation: Long, previousStockValuation: Long): TeamDetailResponse
    }
}

// TeamRankResponse.kt
data class TeamRankResponse(...) {
    companion object {
        fun of(team: Team, totalMoney: Long, myTeamId: UUID): TeamRankResponse
    }
}

// TeamResultResponse.kt - 수익률 계산 + 포맷팅
data class TeamResultResponse(...) {
    companion object {
        fun of(team: Team, lesson: Lesson, currentStockValuation: Long, totalBuyMoney: Long, orderCount: Int): TeamResultResponse
    }
}
```

---

## Mapper 변경
- `ArticleMapper`: `toResponse()`, `toDetailResponse()` 제거
- `ItemMapper`: `toResponse()`, `toDetailResponse()` 제거

---

## Service 변경
Mapper 의존성 제거 → `Response.from()` / `Response.of()` 사용
- QueryArticlesService, QueryArticleDetailService, CreateArticleService, UpdateArticleService
- QueryItemsService, QueryItemDetailService, CreateItemService, UpdateItemService
- CreateLessonService, UpdateLessonService
- QueryLessonRoundItemsService, QueryLessonItemDetailService
- QueryStocksService, QueryHoldStocksService, QueryTradingDetailService
- QueryTeamDetailService, QueryTeamRanksService, QueryTeamResultService

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **Refactor**
  * 내부 코드 구조를 개선하여 응답 데이터 변환 로직을 최적화했습니다. 서비스의 성능과 안정성은 유지되며, 사용자는 동일한 기능을 계속 이용할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->